### PR TITLE
Align all .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,24 @@
+# IDE / Editors
+.vscode
+.idea
+*.sublime-project
+*.sublime-workspace
+
+
+# R specific:
 .Rproj.user
 .Rhistory
 .RData
 .Ruserdata
-.env
+
+# Generic ignored files:
+*~
+*.sw[mnpcod]
+.tmp
+*.tmp
+*.tmp.*
+.DS_Store
+Thumbs.db
+UserInterfaceState.xcuserstate
+$RECYCLE.BIN/
+*.log*

--- a/interfaces/overview/.gitignore
+++ b/interfaces/overview/.gitignore
@@ -1,18 +1,37 @@
-# Build Configuration/secrets:
+# IDE / Editors
+.vscode
+.idea
+*.sublime-project
+*.sublime-workspace
+
+
+# Configuration, secrets, etc:
 .env
 environment.prod.ts
 
-# Default ignore-rules set by Ionic/Angular:
-/.ionic
-/.sass-cache
-/.sourcemaps
-/.versions
-/coverage
-/dist
-/node_modules
-/platforms
-/plugins
-/www
 
-# Assets generated/included during build
+# Assets ONLY included during build
 src/assets/leaflet
+
+
+# Generated files
+dist
+coverage
+platforms
+plugins
+www
+
+
+# External code
+node_modules
+
+
+# Logs / Cache / temporary files
+logs
+*.log
+npm-debug.log*
+.npm
+.ionic
+.sass-cache
+.sourcemaps
+.versions

--- a/services/API-service/.gitignore
+++ b/services/API-service/.gitignore
@@ -1,24 +1,25 @@
-# Logs
-logs
-*.log
-.DS_Store
-
-npm-debug.log*
-
-# Dependency directory
-node_modules
-
-# Optional npm cache directory
-.npm
-
-#IDEs
+# IDE / Editors
+.vscode
 .idea
+*.sublime-project
+*.sublime-workspace
 
-#config files
+
+# Configuration, secrets, etc:
 .env
 
-# code testing coverage
+
+# Generated files
+dist
 coverage
 
-# generated assets
-dist
+
+# External code
+node_modules
+
+
+# Logs / Cache / temporary files
+logs
+*.log
+npm-debug.log*
+.npm

--- a/services/IBF-pipeline/.gitignore
+++ b/services/IBF-pipeline/.gitignore
@@ -1,10 +1,32 @@
-geoserver/geodata/
-pipeline/data/
-
+# IDE / Editors
 .vscode
-.vscode/*
+.idea
+*.sublime-project
+*.sublime-workspace
 
+
+# Configuration, secrets, etc:
+.env
+Dockerfile
+
+
+# Local data files
+pipeline/data/
 geoserver/
 *.zip
 
-Dockerfile
+
+# Generated files
+dist
+coverage
+
+
+# External code
+node_modules
+
+
+# Logs / Cache / temporary files
+logs
+*.log
+npm-debug.log*
+.npm


### PR DESCRIPTION
There is some duplication across all files, but this way each 'component' (or sub-folder) can be used independently in IDE/editors