### PR TITLE
fix: switch to new waterpoints dataset AB#9112

### DIFF
--- a/services/API-service/src/api/waterpoints/waterpoints.service.ts
+++ b/services/API-service/src/api/waterpoints/waterpoints.service.ts
@@ -28,12 +28,12 @@ export class WaterpointsService {
     }
 
     const path =
-      `https://data.waterpointdata.org/resource/amwk-dedf.geojson` +
+      `https://data.waterpointdata.org/resource/jfkt-jmqa.geojson` +
       `?$where=water_source is not null` +
       ` AND water_source !='Lake'` +
-      ` AND within_polygon(location, '${countryWkt.right}')` +
+      ` AND within_polygon(geocoded_column, '${countryWkt.right}')` +
       `&$limit=100000` +
-      `&status_id=yes` +
+      `&status_id=Yes` +
       `&country_id=${country.countryCodeISO2}`;
 
     return new Promise((resolve, reject): void => {
@@ -42,7 +42,7 @@ export class WaterpointsService {
           const result = response.data;
           result.features.forEach((feature): void => {
             feature.properties = {
-              wpdxId: feature.properties.wpdx_id,
+              wpdxId: feature.properties.row_id,
               activityId: feature.properties.activity_id,
               type: feature.properties.water_source,
               reportDate: feature.properties.report_date.substr(0, 10),


### PR DESCRIPTION
the old waterpoints dataset is inaccessible so I switched to a [new waterpoints dataset](https://data.waterpointdata.org/dataset/Water-Point-Data-Exchange-WPDx-Basic-/jfkt-jmqa). Tested on Uganda, Zambia, Ethiopia, Kenya and Zimbabwe as per [layer-metadata.json](https://github.com/rodekruis/IBF-system/blob/de8b518760e55d19d478e62eaffac18605c437d9/services/API-service/src/scripts/json/layer-metadata.json#L89). It's slow on Uganda because it's loading 95k+ waterpoints, it's fine for the other countries.


![screenshot-data waterpointdata org-2021 08 30-13_42_19](https://user-images.githubusercontent.com/3880591/131355113-5de1b2f4-ee9e-4e88-914c-41e62b7669b0.png)
