### PR TITLE
fix: icon for max warning should use trigger icon

### DIFF
--- a/services/API-service/src/api/notification/email/email-template.service.ts
+++ b/services/API-service/src/api/notification/email/email-template.service.ts
@@ -467,6 +467,7 @@ export class EmailTemplateService {
     const fileNameMap = {
       [EapAlertClassKeyEnum.med]: 'warning-medium.png',
       [EapAlertClassKeyEnum.min]: 'warning-low.png',
+      [EapAlertClassKeyEnum.max]: 'trigger.png',
       default: 'trigger.png',
     };
 


### PR DESCRIPTION


<!--- AB#1234 Only if relevant, start with a link to an issue on Azure DevOps -->

## Describe your changes

icon for max warning should use trigger icon instead of causing an error

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review
