### PR TITLE
fix: use MEMU for malaria

### DIFF
--- a/services/API-service/src/scripts/json/EAP-actions.json
+++ b/services/API-service/src/scripts/json/EAP-actions.json
@@ -999,7 +999,7 @@
       "id": "health"
     },
     "action": "health-1",
-    "label": "Set up Dengue Emergency Medical Units (DEMUs)."
+    "label": "Set up Malaria Emergency Medical Units (MEMUs)."
   },
   {
     "countryCodeISO3": "ETH",


### PR DESCRIPTION
## Describe your changes

We should not have Dengue units for Malaria EAP. Use MEMU until we find the right term.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
