### PR TITLE
fix: remove group by on event trigger value

### DIFF
--- a/services/API-service/src/api/event/event.service.ts
+++ b/services/API-service/src/api/event/event.service.ts
@@ -169,15 +169,10 @@ export class EventService {
   ): SelectQueryBuilder<EventPlaceCodeEntity> {
     return this.eventPlaceCodeRepo
       .createQueryBuilder('event')
-      .select([
-        'area."countryCodeISO3"',
-        'event."eventName"',
-        'event."triggerValue"',
-      ])
+      .select(['area."countryCodeISO3"', 'event."eventName"'])
       .leftJoin('event.adminArea', 'area')
       .groupBy('area."countryCodeISO3"')
       .addGroupBy('event."eventName"')
-      .addGroupBy('event."triggerValue"')
       .addSelect([
         'to_char(MIN("startDate") , \'yyyy-mm-dd\') AS "startDate"',
         'to_char(MAX("endDate") , \'yyyy-mm-dd\') AS "endDate"',

--- a/services/API-service/test/email/flash-flood/test-flash-flood-scenario.helper.ts
+++ b/services/API-service/test/email/flash-flood/test-flash-flood-scenario.helper.ts
@@ -13,7 +13,7 @@ export async function testFlashFloodScenario(
   countryCodeISO3: string,
   accessToken: string,
 ): Promise<void> {
-  const eventNames = ['Rumphi', 'Rumphi', 'Karonga'];
+  const eventNames = ['Rumphi', 'Karonga'];
   const disasterTypeLabel = 'Flash Flood'; // DisasterType.FlashFloods does not match
 
   const mockResult = await mockFlashFlood(

--- a/services/API-service/test/email/typhoon/test-typhoon-scenario.helper.ts
+++ b/services/API-service/test/email/typhoon/test-typhoon-scenario.helper.ts
@@ -13,7 +13,7 @@ export async function testTyphoonScenario(
   countryCodeISO3: string,
   accessToken: string,
 ): Promise<void> {
-  const nrOfEvents = 2;
+  const nrOfEvents = 1;
   const eventName = 'Mock typhoon';
   const disasterTypeLabel = DisasterType.Typhoon;
 


### PR DESCRIPTION
## Describe your changes

Restrict to one event per region.
- This causes event names to be duplicated.

![Screenshot 2024-08-30 at 13 54 44](https://github.com/user-attachments/assets/79c04669-9dfb-4511-92a0-1554cadcd823)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
