### PR TITLE
fix: revert geoserver version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
   ibf-geoserver:
     container_name: ibf-geoserver
-    image: kartoza/geoserver:2.24.2
+    image: kartoza/geoserver:2.19.2
     environment:
       - GEOSERVER_ADMIN_PASSWORD=${GEOSERVER_ADMIN_PASSWORD}
       - JAVA_OPTS="-DALLOW_ENV_PARAMETRIZATION=true"


### PR DESCRIPTION
## Describe your changes

Revert geoserver version update done in [AB#27339](https://dev.azure.com/redcrossnl/IBF%20System/_workitems/edit/27339).

This was tested and reviewed by @gulfaraz and @RubenGeo.
The testing did not include roads and building layers which require [Postgis access via Geoserver](https://stackoverflow.com/questions/76946371/geoserver-parametrized-postgis-database-connection-fails-after-upgrade-from-kart).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
