### PR TITLE
fix: logos should stack horizontally and not vertically

### DIFF
--- a/interfaces/IBF-dashboard/src/app/components/logos/logos.component.scss
+++ b/interfaces/IBF-dashboard/src/app/components/logos/logos.component.scss
@@ -1,3 +1,7 @@
+:host {
+  display: flex;
+}
+
 img {
   height: 3rem;
   padding: 2px;


### PR DESCRIPTION
## Describe your changes

Logos in header should stack horizontally and not vertically.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review