### PR TITLE
fix: use unique id for for loop

### DIFF
--- a/interfaces/IBF-dashboard/src/app/components/chat/chat.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/chat/chat.component.html
@@ -147,93 +147,103 @@
   }
   @for (area of filteredActiveAreas; track area.name; let isFirst = $first) {
     <app-dialogue-turn [isTriggered]="eventState?.event?.thresholdReached">
-      @if (placeCode) {
-        <app-ibf-button
-          (click)="revertAreaSelection()"
-          backgroundColor="ibf-primary"
-          size="small"
-          class="ion-float-right"
-        >
-          <span class="ion-hide-sm-down">{{
-            'chat-component.common.revert-selection' | translate
-          }}</span>
-          <ion-icon name="arrow-back" slot="start"></ion-icon>
-        </app-ibf-button>
-      }
       <ion-row>
-        <ion-col size-lg="2" size-md="2" size-xs="2">
+        <ion-col
+          class="flex flex-row gap-2"
+          size-lg="8"
+          size-md="12"
+          size-sm="8"
+        >
           <ion-img
             src="assets/icons/Alert_Chat_Black.svg"
             class="chat-icon"
           ></ion-img>
-        </ion-col>
-        <ion-col size-lg="10" size-md="10" size-xs="10">
-          <ion-label
-            [innerHTML]="
-              'chat-component.' + disasterTypeName + '.active-event.place-name'
-                | translate
-                  : {
-                      adminAreaLabel,
-                      placeName: area.name,
-                      parentName: getAreaParentString(area),
-                    }
-            "
-          ></ion-label
-          ><br />
-          @if (eventState?.event?.thresholdReached) {
-            <ion-note size="small">
-              <span
-                [innerHTML]="
-                  'chat-component.' + disasterTypeName + '.active-event.exposed'
-                    | translate
-                "
-              ></span>
-              <strong>
-                {{ area.actionsValue | compact: actionIndicatorNumberFormat }}
-              </strong>
-            </ion-note>
-          }
-          <br />
-          @if (countryDisasterSettings?.showMonthlyEapActions) {
-            <div class="ion-margin-bottom">
+          <div>
+            <ion-label
+              [innerHTML]="
+                'chat-component.' +
+                  disasterTypeName +
+                  '.active-event.place-name'
+                  | translate
+                    : {
+                        adminAreaLabel,
+                        placeName: area.name,
+                        parentName: getAreaParentString(area),
+                      }
+              "
+            ></ion-label
+            ><br />
+            @if (eventState?.event?.thresholdReached) {
+              <ion-note size="small">
+                <span
+                  [innerHTML]="
+                    'chat-component.' +
+                      disasterTypeName +
+                      '.active-event.exposed' | translate
+                  "
+                ></span>
+                <strong>
+                  {{ area.actionsValue | compact: actionIndicatorNumberFormat }}
+                </strong>
+              </ion-note>
+            } @else {
+              <ion-note size="small">
+                <span>{{ 'chat-component.common.no-info' | translate }}</span>
+              </ion-note>
+            }
+            <br />
+            @if (countryDisasterSettings?.showMonthlyEapActions) {
               @if (forecastInfo && country?.countryCodeISO3 === 'KEN') {
                 @if (area?.eapActions; as actions) {
-                  <ion-note size="small">
-                    @if (forecastInfo?.length) {
-                      <span
-                        >{{
-                          'chat-component.drought.active-event.forecast-info.opening'
-                            | translate
-                        }}
-                      </span>
-                    }
-                    @for (
-                      forecast of forecastInfo;
-                      track forecast;
-                      let isLast = $last
-                    ) {
-                      <span>
-                        <strong>{{ forecast }}</strong>
-                        @if (!isLast) {
-                          <span>
-                            {{
+                  <div class="ion-margin-bottom">
+                    <ion-note size="small">
+                      @if (forecastInfo?.length) {
+                        <span
+                          >{{
+                            'chat-component.drought.active-event.forecast-info.opening'
+                              | translate
+                          }}
+                        </span>
+                      }
+                      @for (
+                        forecast of forecastInfo;
+                        track forecast;
+                        let isLast = $last
+                      ) {
+                        <span>
+                          <strong>{{ forecast }}</strong>
+                          @if (!isLast) {
+                            <span>{{
                               'chat-component.drought.active-event.forecast-info.and'
                                 | translate
-                            }}
-                          </span>
-                        }
-                      </span>
-                    }
-                    {{ ' ' }}
-                    <span
-                      [innerHTML]="
+                            }}</span>
+                          }
+                        </span>
+                      }
+                      {{ ' ' }}
+                      <span>{{
                         getNumberOfActions(actions.length, forecastInfo?.length)
-                      "
-                    ></span>
-                  </ion-note>
+                      }}</span>
+                    </ion-note>
+                  </div>
                 }
               }
-            </div>
+            }
+          </div>
+        </ion-col>
+        <ion-col size-lg="4" size-md="12" size-sm="4">
+          @if (placeCode) {
+            <app-ibf-button
+              (click)="revertAreaSelection()"
+              backgroundColor="ibf-primary"
+              size="small"
+              class="ion-float-right"
+            >
+              <span class="ion-hide-sm-down">{{
+                'chat-component.common.revert-selection' | translate
+              }}</span>
+              <ion-icon name="arrow-back" slot="start"></ion-icon>
+            </app-ibf-button>
           }
         </ion-col>
       </ion-row>

--- a/interfaces/IBF-dashboard/src/app/components/dialogue-turn/dialogue-turn.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/dialogue-turn/dialogue-turn.component.html
@@ -20,7 +20,7 @@
       (mouseover)="onMouseOver()"
       (mouseout)="onMouseOut()"
     >
-      <ion-card-content>
+      <ion-card-content class="space-y-2">
         <ng-container *ngTemplateOutlet="contentTemplate"></ng-container>
         <small><app-timestamp [timestamp]="timestamp"></app-timestamp></small>
       </ion-card-content>

--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
@@ -211,7 +211,7 @@
       @for (class of alertClasses; track class.alertClass) {
         <div>
           <ul class="list-inside list-disc text-xs">
-            @for (area of class.areas; track area.name) {
+            @for (area of class.areas; track area.eventPlaceCodeId) {
               <li
                 class="my-1 cursor-pointer hover:underline"
                 (click)="selectArea(area)"

--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
@@ -210,21 +210,22 @@
       }
       @for (class of alertClasses; track class.alertClass) {
         <div>
-          <ul class="area-list">
+          <ul class="list-inside list-disc text-xs">
             @for (area of class.areas; track area.name) {
-              <li class="clickable-area" (click)="selectArea(area)">
-                <p>
-                  {{ area.name }}
-                  @if (area.nameParent) {
-                    <span>({{ area.nameParent }})</span>
-                  }
-                  @if (area.actionsValue && area.actionsValue > 0) {
-                    {{ ' - ' }}
-                    <span>{{
-                      area.actionsValue | compact: actionIndicatorNumberFormat
-                    }}</span>
-                  }
-                </p>
+              <li
+                class="my-1 cursor-pointer hover:underline"
+                (click)="selectArea(area)"
+              >
+                {{ area.name }}
+                @if (area.nameParent) {
+                  <span>({{ area.nameParent }})</span>
+                }
+                @if (area.actionsValue && area.actionsValue > 0) {
+                  {{ ' - ' }}
+                  <span>{{
+                    area.actionsValue | compact: actionIndicatorNumberFormat
+                  }}</span>
+                }
               </li>
             }
           </ul>
@@ -267,19 +268,20 @@
             <strong>{{ class.alertClass }}</strong>
           </p>
         }
-        <ul>
+        <ul class="list-inside list-disc text-xs">
           @for (area of class.areas; track area.name) {
-            <li class="clickable-area" (click)="selectArea(area)">
-              <p>
-                {{ area.name }}
-                @if (area.nameParent) {
-                  <span>({{ area.nameParent }})</span>
-                }
-                -
-                <span>{{
-                  area.actionsValue | compact: actionIndicatorNumberFormat
-                }}</span>
-              </p>
+            <li
+              class="my-1 cursor-pointer hover:underline"
+              (click)="selectArea(area)"
+            >
+              {{ area.name }}
+              @if (area.nameParent) {
+                <span>({{ area.nameParent }})</span>
+              }
+              -
+              <span>{{
+                area.actionsValue | compact: actionIndicatorNumberFormat
+              }}</span>
             </li>
           }
         </ul>

--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.scss
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.scss
@@ -19,15 +19,6 @@ ion-checkbox {
   margin-inline-end: 8px !important;
 }
 
-.clickable-area {
-  text-decoration: underline;
-  cursor: pointer;
-
-  :hover {
-    font-weight: bold;
-  }
-}
-
 .event-header {
   display: flex;
   flex-direction: row;

--- a/interfaces/IBF-dashboard/src/assets/i18n/en.json
+++ b/interfaces/IBF-dashboard/src/assets/i18n/en.json
@@ -87,6 +87,7 @@
   },
   "chat-component": {
     "common": {
+      "no-info": "No information available",
       "warn-label": {
         "message": "Hello {{ name }}. The information in this portal is based on the model last run on <strong>{{lastModelRunDate}}</strong>.",
         "tooltip": "The forecast presented on the portal might not be up to date as the model did not run successfully. Contact {{supportEmailAddress}} for further information."


### PR DESCRIPTION
## Describe your changes

This PR includes,
1. A fix for the slow and breaking UI because of the badly configured for loops since the upgrade to ng-18.
2. Make spacing consistent in the chat component.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

1. Try loading all the country-hazard combinations. Before this fix, typhoon and epidemics caused the browser tab to crash due to memory limits.
2. Check the spacing of the chat component in smaller window sizes. I tested against the lg, md, sm and xs breakpoints.

