### PR TITLE
fix: aggregates icon style

### DIFF
--- a/interfaces/IBF-dashboard/src/app/components/aggregates/aggregates.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/aggregates/aggregates.component.html
@@ -36,9 +36,8 @@
         </ion-col>
         <ion-col size-lg="1" size-md="1" size-xs="1">
           <ion-item
-            class="aggregate-item-information-icon ion-no-padding"
+            class="aggregate-item-information-icon ion-no-padding m-0 cursor-pointer"
             data-test="icon-row"
-            style="--inner-padding-end: 0px"
             color="transparent"
             lines="none"
           >
@@ -55,12 +54,16 @@
               <ion-item
                 class="aggregate-item ion-no-padding font-size-12"
                 color="ibf-white"
+                lines="full"
               >
                 <ion-thumbnail
                   slot="start"
-                  class="aggregate-item-thumbnail ion-no-margin"
+                  class="m-0 h-10 w-10 bg-slate-100 p-2"
                 >
-                  <ion-img src="assets/icons/{{ indicator.icon }}"></ion-img>
+                  <ion-img
+                    class="object-contain"
+                    src="assets/icons/{{ indicator.icon }}"
+                  ></ion-img>
                 </ion-thumbnail>
                 <ion-label
                   class="aggregate-item-label ion-no-margin ion-text-wrap"
@@ -78,7 +81,7 @@
               >
                 @if (!isAggregateNan(indicator.name, indicator.weightedAvg)) {
                   <ion-label
-                    class="ion-text-right"
+                    class="ion-text-right m-0"
                     data-test="aggregate-number"
                   >
                     {{
@@ -93,7 +96,10 @@
                     {{ indicator.aggregateUnit }}
                   </ion-label>
                 } @else {
-                  <ion-label class="ion-text-right" data-test="aggregate-na">
+                  <ion-label
+                    class="ion-text-right m-0"
+                    data-test="aggregate-na"
+                  >
                     {{ 'aggregates-component.not-applicable' | translate }}
                   </ion-label>
                 }
@@ -106,14 +112,13 @@
               [title]="'aggregates-component.more-information' | translate"
             >
               <ion-item
-                class="aggregate-item-information-icon ion-no-padding"
+                class="aggregate-item-information-icon ion-no-padding m-0 cursor-pointer"
                 data-test="icon-row"
-                style="--inner-padding-end: 0px"
                 color="ibf-white"
               >
                 <ion-label>
                   <img
-                    class="info-img"
+                    class="mx-auto my-0 w-5"
                     src="assets/icons/source-info.svg"
                     (click)="moreInfo(indicator)"
                   />

--- a/interfaces/IBF-dashboard/src/app/components/aggregates/aggregates.component.scss
+++ b/interfaces/IBF-dashboard/src/app/components/aggregates/aggregates.component.scss
@@ -29,19 +29,6 @@
 .aggregate-item {
   --inner-padding-end: 0;
 
-  .aggregate-item-thumbnail {
-    background: var(--ion-color-fiveten-neutral-100);
-    border: 0.2rem solid var(--ion-color-fiveten-neutral-100);
-    width: 2rem;
-    height: 2rem;
-    align-self: start;
-    padding: 2px;
-
-    ion-img {
-      object-fit: contain;
-    }
-  }
-
   .aggregate-item-label {
     line-height: 1.2;
     white-space: normal;
@@ -50,12 +37,5 @@
 }
 
 .aggregate-item-information-icon {
-  --inner-padding-end: 0.2rem;
-  cursor: pointer;
-
-  ion-label {
-    margin: 0 auto;
-    padding-top: 0.2em;
-    max-width: 20px;
-  }
+  --inner-padding-end: 0;
 }

--- a/interfaces/IBF-dashboard/src/app/components/disclaimer-approximate/disclaimer-approximate.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/disclaimer-approximate/disclaimer-approximate.component.html
@@ -1,4 +1,8 @@
-<img src="assets/icons/source-info.svg" id="disclaimer-approximate-trigger" />
+<img
+  class="mx-auto my-0 w-5"
+  src="assets/icons/source-info.svg"
+  id="disclaimer-approximate-trigger"
+/>
 <ion-popover
   side="right"
   trigger="disclaimer-approximate-trigger"


### PR DESCRIPTION
## Describe your changes

This PR include style changes in the aggregates component as per [design review in this comment](https://github.com/rodekruis/Anticipatory-Action/issues/644#issuecomment-2345444530).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

1. I've used tailwind classes where possible.
2. Here is the screenshot for reference. Note that there is no gap between the icon and the row line.
![Screenshot 2024-09-12 at 15 52 04](https://github.com/user-attachments/assets/ba272006-cf62-4419-8f09-e555f3519264)


