### PR TITLE
fix: make triggered-areas api-call after eventName is set

### DIFF
--- a/interfaces/IBF-dashboard/src/app/components/map/map.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/map/map.component.ts
@@ -657,11 +657,11 @@ export class MapComponent implements AfterViewInit, OnDestroy {
           const event = this.eventState?.events?.find(
             (e) => e.eventName === feature.properties.eventName,
           );
+          this.eventService.switchEvent(feature.properties.eventName);
           this.timelineService.handleTimeStepButtonClick(
             (event?.firstTriggerLeadTime || event?.firstLeadTime) as LeadTime,
             event?.eventName,
           );
-          this.eventService.switchEvent(feature.properties.eventName);
         }
       } else if (this.eventState.event) {
         // if in event-view, then set placeCode


### PR DESCRIPTION
## Describe your changes

Resolves [#857](https://github.com/orgs/rodekruis/projects/23/views/29?pane=issue&itemId=82176000&issue=rodekruis%7CAnticipatory-Action%7C857)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

1. There are multiple strange things at work here. I went for the simplest solution to make sure not to meddle with anything not fully understood. Namely, in the front-end eventName was not passed in the GET /triggered-areas call, because it wasn't set yet at the time of the call. By reversing 2 pieces of code this is fixed. This new order is actually in line with the order of 2 other occurences of the same 2 method calls.
2. I tried to go a step further by eliminating the handleTimestepButtonClick call in all 3 occurences, and instead editing the subscription in timeline.service to also call loadTimestepButtons in onManualEventStateChange. But this did not fully work out of the box, and is too messy to disentangle quickly. So reversed this again.
3. Also the back-end code of GET /triggered-areas is messy. It first runs a query on admin-area-dynamic-data to get triggered areas (using triggerValue>0), which does not get warned areas. Subsequently it queries event-place-code with an optional placeCode IN(...) filter, only if the previous query had results, which it does not for a warning event. (this is the reason why this bug appeared for warning event Karonga only, and not for trigger event Rumphi). 
4. Also here I tried to go a step further by removing this IN-filter altogether, at a hunch it may be irrelevant legacy by now. But this for example leads to also non-triggered areas within event area Rumphi being shown, unlike before, which is apparently not the point. Therefore also reversing this.

