### PR TITLE
fix: do not send any mock exposure data when leadTime > 3 months

### DIFF
--- a/services/API-service/src/scripts/scripts.service.ts
+++ b/services/API-service/src/scripts/scripts.service.ts
@@ -673,7 +673,7 @@ export class ScriptsService {
       triggered
     ) {
       if (Number(activeLeadTime.split('-')[0]) > 3) {
-        copyOfExposureUnit.forEach((area) => (area.amount = 0));
+        copyOfExposureUnit = [];
         // Hard-code lead-times of more then 3 months to non-trigger
       } else if (eventRegion !== this.nationalDroughtRegion) {
         // Hard-code that only areas of right region are triggered per selected leadtime


### PR DESCRIPTION
## Describe your changes

Resolves [bug 859](https://github.com/orgs/rodekruis/projects/23/views/29?pane=issue&itemId=82194439&issue=rodekruis%7CAnticipatory-Action%7C859)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

1. I basically reversed the previous edit on this same line of code, which was - according to the commit message - done to fix ZWE mock. But this code is within an IF, which specifically excludes ZWE.
2. So I reversed it and checked both for Ethiopia (fixes the bug) and for Zimbabwe (still works fine).
3. This is a mock only bug. Production pipeline should take care of not sending any data for more than 3 months leadTime.

