### PR TITLE
feat: reverse multi-threshold other countries

### DIFF
--- a/services/API-service/src/scripts/json/countries.json
+++ b/services/API-service/src/scripts/json/countries.json
@@ -409,17 +409,6 @@
             "color": "ibf-no-alert-primary",
             "value": 0
           },
-          "min": {
-            "label": "Low warning issued",
-            "color": "fiveten-yellow-500",
-            "textColor": "fiveten-yellow-700",
-            "value": 0.3
-          },
-          "med": {
-            "label": "Medium warning issued",
-            "color": "ibf-orange",
-            "value": 0.7
-          },
           "max": {
             "label": "Trigger issued",
             "color": "ibf-glofas-trigger",
@@ -516,17 +505,6 @@
             "color": "ibf-no-alert-primary",
             "value": 0
           },
-          "min": {
-            "label": "Low warning issued",
-            "color": "fiveten-yellow-500",
-            "textColor": "fiveten-yellow-700",
-            "value": 0.3
-          },
-          "med": {
-            "label": "Medium warning issued",
-            "color": "ibf-orange",
-            "value": 0.7
-          },
           "max": {
             "label": "Trigger issued",
             "color": "ibf-glofas-trigger",
@@ -592,17 +570,6 @@
             "label": "No action",
             "color": "ibf-no-alert-primary",
             "value": 0
-          },
-          "min": {
-            "label": "Low warning issued",
-            "color": "fiveten-yellow-500",
-            "textColor": "fiveten-yellow-700",
-            "value": 0.3
-          },
-          "med": {
-            "label": "Medium warning issued",
-            "color": "ibf-orange",
-            "value": 0.7
           },
           "max": {
             "label": "Trigger issued",
@@ -720,17 +687,6 @@
             "label": "No action",
             "color": "ibf-no-alert-primary",
             "value": 0
-          },
-          "min": {
-            "label": "Low warning issued",
-            "color": "fiveten-yellow-500",
-            "textColor": "fiveten-yellow-700",
-            "value": 0.3
-          },
-          "med": {
-            "label": "Medium warning issued",
-            "color": "ibf-orange",
-            "value": 0.7
           },
           "max": {
             "label": "Trigger issued",
@@ -1155,17 +1111,6 @@
             "label": "No action",
             "color": "ibf-no-alert-primary",
             "value": 0
-          },
-          "min": {
-            "label": "Low warning issued",
-            "color": "fiveten-yellow-500",
-            "textColor": "fiveten-yellow-700",
-            "value": 0.3
-          },
-          "med": {
-            "label": "Medium warning issued",
-            "color": "ibf-orange",
-            "value": 0.7
           },
           "max": {
             "label": "Trigger issued",


### PR DESCRIPTION
## Describe your changes

Final chore of #1554 .
Reverses multi-threshold settings in IBF-portal for other countries then UGA and ZMB. In practice the only thing this achieves (on top of the multi-thresholds settings being reversed already in the pipeline) is that the map legend shows only 2 Glofas stations items instead of 4 for those  countries.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

1. Any helpful instructions or clarifications...

