### PR TITLE
ci: run e2e and integration tests only when api-service or dashboard changes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -71,10 +71,7 @@ jobs:
 
   ibf-integration:
     needs: detect-changes
-    if: ${{
-      needs.detect-changes.outputs.ibf-api-service == 'true' ||
-      needs.detect-changes.outputs.ibf-dashboard == 'true'
-      }}
+    if: ${{ needs.detect-changes.outputs.ibf-api-service == 'true' }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -70,6 +70,12 @@ jobs:
       - run: npm test
 
   ibf-integration:
+    needs: detect-changes
+    if: ${{
+      needs.detect-changes.outputs.ibf-api-service == 'true' ||
+      needs.detect-changes.outputs.ibf-dashboard == 'true'
+      }}
+
     runs-on: ubuntu-latest
 
     steps:
@@ -80,6 +86,12 @@ jobs:
           mailchimp-api-key: ${{ secrets.MC_API }}
 
   ibf-e2e:
+    needs: detect-changes
+    if: ${{
+      needs.detect-changes.outputs.ibf-api-service == 'true' ||
+      needs.detect-changes.outputs.ibf-dashboard == 'true'
+      }}
+
     runs-on: ubuntu-latest
 
     steps:
@@ -113,4 +125,3 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           git-message: 'chore(release): {version}'
           release-count: 10
-


### PR DESCRIPTION
## Describe your changes

The e2e and integration tests must only run when we change the dashboard or API-service.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review