### PR TITLE
fix: center email header logo on outlook for windows

### DIFF
--- a/services/API-service/src/api/notification/email/mjml/header.ts
+++ b/services/API-service/src/api/notification/email/mjml/header.ts
@@ -18,7 +18,7 @@ export const getMjmlHeader = ({
 }): object => {
   const logosElement = {
     tagName: 'mj-raw',
-    content: `<img src="${logosSrc}" style="display: block; height: 50px; width: auto; margin: auto; background: ${COLOR_WHITE};" />`,
+    content: `<div style="text-align: center;"><img src="${logosSrc}" style="display: block; height: 50px; width: auto; margin: auto; background: ${COLOR_WHITE};" /></div>`,
   };
 
   const titleElement = getTextElement({


### PR DESCRIPTION
## Describe your changes

The header logo of the email is not centered on Outlook for Windows

### Before the fix
![image](https://github.com/user-attachments/assets/dc178c73-1aa0-4ef6-a662-d0a07eedba7b)

### After the fix
![image](https://github.com/user-attachments/assets/0071a33b-ae53-455b-85cb-626fdae9e347)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review

