### PR TITLE
fix: skip typhoon national view if 2 warning events

### DIFF
--- a/interfaces/IBF-dashboard/src/app/services/event.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/event.service.ts
@@ -230,7 +230,7 @@ export class EventService {
       this.setEventInitially(events[0]);
     } else if (this.skipNationalView(this.disasterType.disasterType)) {
       const triggerEvents = events.filter((e) => e.thresholdReached);
-      const eventToLoad = triggerEvents ? triggerEvents[0] : events[0];
+      const eventToLoad = triggerEvents.length ? triggerEvents[0] : events[0];
       this.setEventInitially(eventToLoad);
     } else {
       this.setEventInitially(null);


### PR DESCRIPTION
## Describe your changes

Correctly skip national view also if only warning events

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

1. Any helpful instructions or clarifications...

