### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    open-pull-requests-limit: 5
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    open-pull-requests-limit: 5
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/services/API-service'
+    open-pull-requests-limit: 5
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/interfaces/IBF-dashboard'
+    open-pull-requests-limit: 5
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/tests/integration'
+    open-pull-requests-limit: 5
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/tests/e2e'
+    open-pull-requests-limit: 5
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
## Describe your changes

Adds a dependabot config for github-actions, [IBF-system](https://github.com/rodekruis/IBF-system/blob/809150dbbb102681ca931d436b504274a8aab45b/package.json), [IBF-dashboard](https://github.com/rodekruis/IBF-system/tree/809150dbbb102681ca931d436b504274a8aab45b/interfaces/IBF-dashboard), [API-service](https://github.com/rodekruis/IBF-system/tree/809150dbbb102681ca931d436b504274a8aab45b/services/API-service), [e2e tests](https://github.com/rodekruis/IBF-system/tree/809150dbbb102681ca931d436b504274a8aab45b/tests/e2e), and [integration tests](https://github.com/rodekruis/IBF-system/tree/809150dbbb102681ca931d436b504274a8aab45b/tests/integration).

## Notes for the reviewer

1. I enabled the dependabot settings in GitHub.
2. We can adjust the config if this config leads to spammy PRs.

