### PR TITLE
Fix.filter area list exposed only

### DIFF
--- a/interfaces/IBF-dashboard/src/app/components/chat/chat.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/chat/chat.component.html
@@ -65,21 +65,19 @@
       @if (
         filteredStoppedAreas.length === 0 && filteredActiveAreas.length === 0
       ) {
-        @if (activeAreas.length) {
-          <app-event-speech-bubble
-            [type]="'active'"
-            [event]="event"
-            [selectedEvent]="eventState?.event?.eventName"
-            [disasterTypeLabel]="disasterType?.label"
-            [disasterTypeName]="disasterType?.disasterType"
-            [clearOutMessage]="getClearOutMessage(event)"
-            [countryCodeISO3]="country?.countryCodeISO3"
-            [areas]="activeAreas"
-            [adminAreaLabelPlural]="adminAreaLabelPlural"
-            [actionIndicatorLabel]="actionIndicatorLabel"
-            [actionIndicatorNumberFormat]="actionIndicatorNumberFormat"
-          ></app-event-speech-bubble>
-        }
+        <app-event-speech-bubble
+          [type]="'active'"
+          [event]="event"
+          [selectedEvent]="eventState?.event?.eventName"
+          [disasterTypeLabel]="disasterType?.label"
+          [disasterTypeName]="disasterType?.disasterType"
+          [clearOutMessage]="getClearOutMessage(event)"
+          [countryCodeISO3]="country?.countryCodeISO3"
+          [areas]="activeAreas"
+          [adminAreaLabelPlural]="adminAreaLabelPlural"
+          [actionIndicatorLabel]="actionIndicatorLabel"
+          [actionIndicatorNumberFormat]="actionIndicatorNumberFormat"
+        ></app-event-speech-bubble>
         @if (stoppedAreas.length) {
           <app-event-speech-bubble
             [type]="'stopped'"

--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
@@ -208,29 +208,27 @@
           "
         ></p>
       }
-      @for (class of alertClasses; track class.alertClass) {
-        <div>
-          <ul class="list-inside list-disc text-xs">
-            @for (area of class.areas; track area.eventPlaceCodeId) {
-              <li
-                class="my-1 cursor-pointer hover:underline"
-                (click)="selectArea(area)"
-              >
-                {{ area.name }}
-                @if (area.nameParent) {
-                  <span>({{ area.nameParent }})</span>
-                }
-                @if (area.actionsValue && area.actionsValue > 0) {
-                  {{ ' - ' }}
-                  <span>{{
-                    area.actionsValue | compact: actionIndicatorNumberFormat
-                  }}</span>
-                }
-              </li>
-            }
-          </ul>
-        </div>
-      }
+      <div>
+        <ul class="list-inside list-disc text-xs">
+          @for (area of areas; track area.eventPlaceCodeId) {
+            <li
+              class="my-1 cursor-pointer hover:underline"
+              (click)="selectArea(area)"
+            >
+              {{ area.name }}
+              @if (area.nameParent) {
+                <span>({{ area.nameParent }})</span>
+              }
+              @if (area.actionsValue && area.actionsValue > 0) {
+                {{ ' - ' }}
+                <span>{{
+                  area.actionsValue | compact: actionIndicatorNumberFormat
+                }}</span>
+              }
+            </li>
+          }
+        </ul>
+      </div>
       @if (event.thresholdReached) {
         <p
           [translate]="
@@ -261,32 +259,25 @@
               }
       "
     ></p>
-    @for (class of alertClasses; track class.alertClass) {
-      <div>
-        @if (class.alertClass !== 'undefined') {
-          <p class="ion-padding-top">
-            <strong>{{ class.alertClass }}</strong>
-          </p>
+    <div>
+      <ul class="list-inside list-disc text-xs">
+        @for (area of areas; track area.eventPlaceCodeId) {
+          <li
+            class="my-1 cursor-pointer hover:underline"
+            (click)="selectArea(area)"
+          >
+            {{ area.name }}
+            @if (area.nameParent) {
+              <span>({{ area.nameParent }})</span>
+            }
+            -
+            <span>{{
+              area.actionsValue | compact: actionIndicatorNumberFormat
+            }}</span>
+          </li>
         }
-        <ul class="list-inside list-disc text-xs">
-          @for (area of class.areas; track area.eventPlaceCodeId) {
-            <li
-              class="my-1 cursor-pointer hover:underline"
-              (click)="selectArea(area)"
-            >
-              {{ area.name }}
-              @if (area.nameParent) {
-                <span>({{ area.nameParent }})</span>
-              }
-              -
-              <span>{{
-                area.actionsValue | compact: actionIndicatorNumberFormat
-              }}</span>
-            </li>
-          }
-        </ul>
-      </div>
-    }
+      </ul>
+    </div>
     <p
       [translate]="
         'chat-component.' + disasterTypeName + '.stopped-event.instruction'

--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
@@ -133,7 +133,7 @@
           >
         }
       </p>
-      @if (event.affectedAreas) {
+      @if (nrAffectedAreas > 0) {
         <p>
           <strong
             >{{
@@ -141,7 +141,7 @@
                 | translate: { adminAreaLabelPlural: adminAreaLabelPlural }
             }}
           </strong>
-          <span>{{ event.affectedAreas + ' ' }}</span>
+          <span>{{ nrAffectedAreas + ' ' }}</span>
           @if (event.thresholdReached) {
             <span>{{
               '(' +

--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
@@ -140,7 +140,7 @@
               | translate: { adminAreaLabelPlural: adminAreaLabelPlural }
           }}
         </strong>
-        <span>{{ nrAffectedAreas + ' ' }}</span>
+        <span>{{ event.nrAffectedAreas + ' ' }}</span>
         @if (event.thresholdReached) {
           <span>{{
             '(' +

--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
@@ -133,35 +133,33 @@
           >
         }
       </p>
-      @if (nrAffectedAreas > 0) {
-        <p>
-          <strong
-            >{{
-              'chat-component.' + disasterTypeName + '.alertLevel.exposed-areas'
-                | translate: { adminAreaLabelPlural: adminAreaLabelPlural }
-            }}
-          </strong>
-          <span>{{ nrAffectedAreas + ' ' }}</span>
-          @if (event.thresholdReached) {
-            <span>{{
+      <p>
+        <strong
+          >{{
+            'chat-component.' + disasterTypeName + '.alertLevel.exposed-areas'
+              | translate: { adminAreaLabelPlural: adminAreaLabelPlural }
+          }}
+        </strong>
+        <span>{{ nrAffectedAreas + ' ' }}</span>
+        @if (event.thresholdReached) {
+          <span>{{
+            '(' +
+              (actionIndicatorLabel | titlecase) +
+              ' ' +
+              (event.actionsValueSum | compact) +
+              ')'
+          }}</span>
+        } @else {
+          <span>
+            {{
               '(' +
-                (actionIndicatorLabel | titlecase) +
-                ' ' +
-                (event.actionsValueSum | compact) +
+                ('chat-component.' + disasterTypeName + '.alertLevel.no-data'
+                  | translate) +
                 ')'
-            }}</span>
-          } @else {
-            <span>
-              {{
-                '(' +
-                  ('chat-component.' + disasterTypeName + '.alertLevel.no-data'
-                    | translate) +
-                  ')'
-              }}
-            </span>
-          }
-        </p>
-      }
+            }}
+          </span>
+        }
+      </p>
     }
 
     @if (typhoonLandfallText) {

--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.ts
@@ -54,7 +54,6 @@ export class EventSpeechBubbleComponent implements AfterViewChecked, OnDestroy {
   public isStopped: boolean;
   private placeCodeHoverSubscription: Subscription;
   public placeCodeHover: PlaceCode;
-  public alertClasses: { alertClass: string; areas: TriggeredArea[] }[];
 
   constructor(
     private authService: AuthService,
@@ -70,8 +69,7 @@ export class EventSpeechBubbleComponent implements AfterViewChecked, OnDestroy {
     if (this.authService.displayName) {
       this.displayName = this.authService.displayName;
     }
-
-    this.alertClasses = this.splitAreasByAlertClass(this.areas);
+    console.log('areas: ', this.areas);
 
     this.placeCodeHoverSubscription = this.placeCodeService
       .getPlaceCodeHoverSubscription()
@@ -86,24 +84,6 @@ export class EventSpeechBubbleComponent implements AfterViewChecked, OnDestroy {
 
   ngOnDestroy() {
     this.placeCodeHoverSubscription.unsubscribe();
-  }
-
-  public splitAreasByAlertClass(
-    areas: TriggeredArea[] = [],
-  ): { alertClass: string; areas: TriggeredArea[] }[] {
-    const areasByAlertClass = {};
-
-    for (const area of areas) {
-      if (!areasByAlertClass[area.alertClass]) {
-        areasByAlertClass[area.alertClass] = [];
-      }
-      areasByAlertClass[area.alertClass].push(area);
-    }
-
-    return Object.keys(areasByAlertClass).map((alertClass) => ({
-      alertClass: alertClass,
-      areas: areasByAlertClass[alertClass],
-    }));
   }
 
   public selectArea(area) {

--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.ts
@@ -54,7 +54,6 @@ export class EventSpeechBubbleComponent implements AfterViewChecked, OnDestroy {
   public isStopped: boolean;
   private placeCodeHoverSubscription: Subscription;
   public placeCodeHover: PlaceCode;
-  public nrAffectedAreas: number;
 
   constructor(
     private authService: AuthService,
@@ -79,9 +78,6 @@ export class EventSpeechBubbleComponent implements AfterViewChecked, OnDestroy {
 
     if (this.event) {
       this.event['header'] = this.getHeader(this.event);
-      this.nrAffectedAreas = this.areas.filter(
-        (a) => a.eventName === this.event.eventName,
-      ).length;
     }
   }
 

--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.ts
@@ -54,6 +54,7 @@ export class EventSpeechBubbleComponent implements AfterViewChecked, OnDestroy {
   public isStopped: boolean;
   private placeCodeHoverSubscription: Subscription;
   public placeCodeHover: PlaceCode;
+  public nrAffectedAreas: number;
 
   constructor(
     private authService: AuthService,
@@ -69,7 +70,6 @@ export class EventSpeechBubbleComponent implements AfterViewChecked, OnDestroy {
     if (this.authService.displayName) {
       this.displayName = this.authService.displayName;
     }
-    console.log('areas: ', this.areas);
 
     this.placeCodeHoverSubscription = this.placeCodeService
       .getPlaceCodeHoverSubscription()
@@ -79,6 +79,9 @@ export class EventSpeechBubbleComponent implements AfterViewChecked, OnDestroy {
 
     if (this.event) {
       this.event['header'] = this.getHeader(this.event);
+      this.nrAffectedAreas = this.areas.filter(
+        (a) => a.eventName === this.event.eventName,
+      ).length;
     }
   }
 

--- a/interfaces/IBF-dashboard/src/app/services/eap-actions.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/eap-actions.service.ts
@@ -135,7 +135,9 @@ export class EapActionsService {
   }
 
   private onTriggeredAreas = (triggeredAreas) => {
-    this.triggeredAreas = triggeredAreas;
+    this.triggeredAreas = triggeredAreas.filter(
+      (area) => area.actionsValue > 0,
+    ); // REFACTOR: Quick fix to filter out areas with 0 exposure. Properly solve later.
     this.triggeredAreas.sort((a, b) => {
       if (a.triggerValue === b.triggerValue) {
         return a.actionsValue > b.actionsValue ? -1 : 1;

--- a/interfaces/IBF-dashboard/src/app/services/eap-actions.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/eap-actions.service.ts
@@ -136,8 +136,8 @@ export class EapActionsService {
 
   private onTriggeredAreas = (triggeredAreas) => {
     this.triggeredAreas = triggeredAreas.filter(
-      (area) => area.actionsValue > 0,
-    ); // REFACTOR: Quick fix to filter out areas with 0 exposure. Properly solve later.
+      (area) => area.actionsValue > 0 || area.triggerValue > 0,
+    ); // REFACTOR: Quick fix to filter out areas with 0 exposure (PHL typhoon), but at the same time not filter out warning-areas in UGA floods. Properly solve later.
     this.triggeredAreas.sort((a, b) => {
       if (a.triggerValue === b.triggerValue) {
         return a.actionsValue > b.actionsValue ? -1 : 1;

--- a/interfaces/IBF-dashboard/src/app/services/eap-actions.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/eap-actions.service.ts
@@ -135,9 +135,7 @@ export class EapActionsService {
   }
 
   private onTriggeredAreas = (triggeredAreas) => {
-    this.triggeredAreas = triggeredAreas.filter(
-      (area) => area.actionsValue > 0 || area.triggerValue > 0,
-    ); // REFACTOR: Quick fix to filter out areas with 0 exposure (PHL typhoon), but at the same time not filter out warning-areas in UGA floods. Properly solve later.
+    this.triggeredAreas = triggeredAreas;
     this.triggeredAreas.sort((a, b) => {
       if (a.triggerValue === b.triggerValue) {
         return a.actionsValue > b.actionsValue ? -1 : 1;

--- a/interfaces/IBF-dashboard/src/app/services/eap-actions.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/eap-actions.service.ts
@@ -185,21 +185,6 @@ export class EapActionsService {
   };
 
   private mapTriggerValueToAlertClass = (triggeredArea: TriggeredArea) => {
-    // If no match is found, then no alertClass will be shown
-    if (this.countryDisasterSettings.eapAlertClasses) {
-      for (const alertClass of Object.keys(
-        this.countryDisasterSettings.eapAlertClasses,
-      )) {
-        if (
-          triggeredArea.triggerValue ===
-          this.countryDisasterSettings.eapAlertClasses[alertClass].value
-        ) {
-          triggeredArea.alertClass =
-            this.countryDisasterSettings.eapAlertClasses[alertClass].label;
-        }
-      }
-    }
-
     if (triggeredArea.triggerValue === 1) {
       triggeredArea.alertLabel = AlertLabel.trigger;
     } else if (triggeredArea.triggerValue > 0) {

--- a/interfaces/IBF-dashboard/src/app/services/event.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/event.service.ts
@@ -35,6 +35,7 @@ export class EventSummary {
   duration?: number;
   disasterSpecificProperties: DisasterSpecificProperties;
   header?: string;
+  nrAffectedAreas?: number;
   actionsValueSum?: number;
 }
 

--- a/interfaces/IBF-dashboard/src/app/services/event.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/event.service.ts
@@ -35,7 +35,6 @@ export class EventSummary {
   duration?: number;
   disasterSpecificProperties: DisasterSpecificProperties;
   header?: string;
-  affectedAreas?: number;
   actionsValueSum?: number;
 }
 

--- a/interfaces/IBF-dashboard/src/app/types/triggered-area.ts
+++ b/interfaces/IBF-dashboard/src/app/types/triggered-area.ts
@@ -7,6 +7,7 @@ export class TriggeredArea {
   displayName: string;
   eapActions: EapAction[];
   eventPlaceCodeId: string;
+  eventName: string;
   name: string;
   nameParent: string;
   placeCode: string;

--- a/interfaces/IBF-dashboard/src/app/types/triggered-area.ts
+++ b/interfaces/IBF-dashboard/src/app/types/triggered-area.ts
@@ -7,7 +7,6 @@ export class TriggeredArea {
   displayName: string;
   eapActions: EapAction[];
   eventPlaceCodeId: string;
-  eventName: string;
   name: string;
   nameParent: string;
   placeCode: string;

--- a/interfaces/IBF-dashboard/src/app/types/triggered-area.ts
+++ b/interfaces/IBF-dashboard/src/app/types/triggered-area.ts
@@ -15,7 +15,6 @@ export class TriggeredArea {
   stopped: boolean;
   stoppedDate: string;
   submitDisabled: boolean;
-  alertClass?: string;
   alertLabel?: AlertLabel;
 }
 

--- a/services/API-service/src/api/event/event.service.ts
+++ b/services/API-service/src/api/event/event.service.ts
@@ -354,7 +354,7 @@ export class EventService {
     if (eventName) {
       whereFiltersEvent['eventName'] = eventName;
     }
-    const triggeredAreasQuery = this.eventPlaceCodeRepo
+    const triggeredAreas = await this.eventPlaceCodeRepo
       .createQueryBuilder('event')
       .select([
         'area."placeCode" AS "placeCode"',
@@ -366,7 +366,6 @@ export class EventService {
         'event."stopped"',
         'event."startDate"',
         'event."manualStoppedDate" AS "stoppedDate"',
-        'event."eventName" as "eventName"',
         '"user"."firstName" || \' \' || "user"."lastName" AS "displayName"',
         'parent.name AS "nameParent"',
       ])
@@ -381,14 +380,9 @@ export class EventService {
       .andWhere('area."countryCodeISO3" = :countryCodeISO3', {
         countryCodeISO3: countryCodeISO3,
       })
-      .orderBy('event."actionsValue"', 'DESC');
-
-    if (triggeredPlaceCodes.length) {
-      triggeredAreasQuery.andWhere('area."placeCode" IN(:...placeCodes)', {
-        placeCodes: triggeredPlaceCodes,
-      });
-    }
-    const triggeredAreas = await triggeredAreasQuery.getRawMany();
+      .andWhere('(event."actionsValue" > 0 OR event."triggerValue" > 0)')
+      .orderBy('event."actionsValue"', 'DESC')
+      .getRawMany();
 
     for (const area of triggeredAreas) {
       if (triggeredPlaceCodes.length === 0) {

--- a/services/API-service/src/api/event/event.service.ts
+++ b/services/API-service/src/api/event/event.service.ts
@@ -479,6 +479,7 @@ export class EventService {
         startDate: area.startDate,
         stoppedDate: area.stoppedDate,
         displayName: area.displayName,
+        eventName: eventName,
         eapActions: [],
       };
     });

--- a/services/API-service/src/api/event/event.service.ts
+++ b/services/API-service/src/api/event/event.service.ts
@@ -174,7 +174,6 @@ export class EventService {
         'to_char(MIN("startDate") , \'yyyy-mm-dd\') AS "startDate"',
         'to_char(MAX("endDate") , \'yyyy-mm-dd\') AS "endDate"',
         'MAX(event."thresholdReached"::int)::boolean AS "thresholdReached"',
-        'count(event."adminAreaId")::int AS "affectedAreas"',
         'MAX(event."triggerValue")::float AS "triggerValue"',
         'sum(event."actionsValue")::int AS "actionsValueSum"',
       ])
@@ -366,6 +365,7 @@ export class EventService {
         'event."stopped"',
         'event."startDate"',
         'event."manualStoppedDate" AS "stoppedDate"',
+        'event."eventName" as "eventName"',
         '"user"."firstName" || \' \' || "user"."lastName" AS "displayName"',
         'parent.name AS "nameParent"',
       ])

--- a/services/API-service/src/api/event/event.service.ts
+++ b/services/API-service/src/api/event/event.service.ts
@@ -174,6 +174,7 @@ export class EventService {
         'to_char(MIN("startDate") , \'yyyy-mm-dd\') AS "startDate"',
         'to_char(MAX("endDate") , \'yyyy-mm-dd\') AS "endDate"',
         'MAX(event."thresholdReached"::int)::boolean AS "thresholdReached"',
+        'SUM(CASE WHEN event."actionsValue" > 0 OR event."triggerValue" > 0 THEN 1 ELSE 0 END) AS "nrAffectedAreas"', // This count is needed here, because the portal also needs the count of other events when in event view, which it cannot get any more from the triggeredAreas array length, which is then filtered on selected event only
         'MAX(event."triggerValue")::float AS "triggerValue"',
         'sum(event."actionsValue")::int AS "actionsValueSum"',
       ])
@@ -479,7 +480,6 @@ export class EventService {
         startDate: area.startDate,
         stoppedDate: area.stoppedDate,
         displayName: area.displayName,
-        eventName: eventName,
         eapActions: [],
       };
     });

--- a/services/API-service/src/api/notification/email/mjml/event-admin-area-table.ts
+++ b/services/API-service/src/api/notification/email/mjml/event-admin-area-table.ts
@@ -65,19 +65,17 @@ const getMjmlEventAdminAreaTable = ({
     },
   });
 
-  const adminAreaList = event.triggeredAreas
-    .filter(({ actionsValue }) => actionsValue)
-    .map((triggeredArea) => {
-      return {
-        exposed: toCompactNumber(
-          triggeredArea.actionsValue,
-          indicatorMetadata.numberFormatMap,
-        ),
-        name: `${triggeredArea.name} ${
-          triggeredArea.nameParent ? `(${triggeredArea.nameParent})` : ''
-        }`,
-      };
-    });
+  const adminAreaList = event.triggeredAreas.map((triggeredArea) => {
+    return {
+      exposed: toCompactNumber(
+        triggeredArea.actionsValue,
+        indicatorMetadata.numberFormatMap,
+      ),
+      name: `${triggeredArea.name} ${
+        triggeredArea.nameParent ? `(${triggeredArea.nameParent})` : ''
+      }`,
+    };
+  });
 
   const adminAreaTable = getAdminAreaTable({
     adminAreaList,

--- a/services/API-service/src/api/notification/notification-content/notification-content.service.ts
+++ b/services/API-service/src/api/notification/notification-content/notification-content.service.ts
@@ -177,11 +177,7 @@ export class NotificationContentService {
       disasterType,
       event,
     );
-    data.nrOfTriggeredAreas = await this.getNrOfTriggeredAreas(
-      data.triggeredAreas,
-      data.triggerStatusLabel,
-      disasterType,
-    );
+    data.nrOfTriggeredAreas = data.triggeredAreas.length;
     // This looks weird, but as far as I understand the startDate of the event is the day it was first issued
     data.issuedDate = new Date(event.startDate);
     data.firstLeadTimeString = await this.getFirstLeadTimeString(
@@ -202,28 +198,6 @@ export class NotificationContentService {
     );
     data.eapAlertClass = event.disasterSpecificProperties?.eapAlertClass;
     return data;
-  }
-
-  private async getNrOfTriggeredAreas(
-    triggeredAreas: TriggeredArea[],
-    statusLabel: TriggerStatusLabelEnum,
-    disasterType: DisasterType,
-  ): Promise<number> {
-    // This filters out the areas that are affected by the event but do not have any affect action units
-    // Affected action units are for example people_affected, houses_affected, etc (differs per disaster type)
-    // We are not sure why this is done, but it is done in the original code
-    // For warning flood events this is not done, because there are no flood extens for warning events so we do not know any actions values
-    if (
-      disasterType === DisasterType.Floods &&
-      statusLabel === TriggerStatusLabelEnum.Warning
-    ) {
-      return triggeredAreas.length;
-    } else {
-      const triggeredAreasWithoutActionValue = triggeredAreas.filter(
-        (a) => a.actionsValue > 0,
-      );
-      return triggeredAreasWithoutActionValue.length;
-    }
   }
 
   private async getSortedTriggeredAreas(

--- a/services/API-service/src/shared/data.model.ts
+++ b/services/API-service/src/shared/data.model.ts
@@ -54,9 +54,6 @@ export class TriggeredArea {
 
   @ApiProperty({ example: 'Henry Dunant' })
   public displayName: string;
-
-  @ApiProperty({ example: 'G1966' })
-  public eventName: string;
 }
 
 export class EapAlertClass {
@@ -110,4 +107,7 @@ export class EventSummaryCountry {
 
   @ApiProperty({ example: 100 })
   public triggerValue: number;
+
+  @ApiProperty({ example: 5 })
+  public nrAffectedAreas: number;
 }

--- a/services/API-service/src/shared/data.model.ts
+++ b/services/API-service/src/shared/data.model.ts
@@ -54,6 +54,9 @@ export class TriggeredArea {
 
   @ApiProperty({ example: 'Henry Dunant' })
   public displayName: string;
+
+  @ApiProperty({ example: 'G1966' })
+  public eventName: string;
 }
 
 export class EapAlertClass {
@@ -107,7 +110,4 @@ export class EventSummaryCountry {
 
   @ApiProperty({ example: 100 })
   public triggerValue: number;
-
-  @ApiProperty({ example: 5 })
-  public affectedAreas: number;
 }


### PR DESCRIPTION
## Describe your changes

- Resolves [issue 889](https://github.com/rodekruis/Anticipatory-Action/issues/889). In the end by filtering in the front-end, similar to how the email list is filtered. 
- This solves the typhoon issue of showing 1647 areas for warning events.
- For floods, we're accepting for now that this means that the map will still show more areas potentially than the area list. At least the area list coincides with the email.
- Additionally, calculate aggregate count based on the filtered array, not on separate backend property.
- Unrelated, but remove outdated split by alertClass in area-list. 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

1. Any helpful instructions or clarifications...

