### PR TITLE
test: remove CUSTOM SCHEMA warnings

### DIFF
--- a/interfaces/IBF-dashboard/src/app/components/about-btn/about-btn.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/about-btn/about-btn.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
@@ -15,6 +16,7 @@ describe('AboutBtnComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [AboutBtnComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [IonicModule, RouterTestingModule],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),

--- a/interfaces/IBF-dashboard/src/app/components/activation-log-button/activation-log-button.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/activation-log-button/activation-log-button.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
@@ -16,6 +17,7 @@ describe('ActivationLogButtonComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ActivationLogButtonComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [
         IonicModule.forRoot(),
         RouterTestingModule,

--- a/interfaces/IBF-dashboard/src/app/components/change-password-popover/change-password-popover.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/change-password-popover/change-password-popover.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -17,6 +18,7 @@ describe('ChangePasswordPopoverComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ChangePasswordPopoverComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [IonicModule.forRoot(), FormsModule, RouterTestingModule],
       providers: [
         { provide: AuthService },

--- a/interfaces/IBF-dashboard/src/app/components/community-notification-popup/community-notification-popup.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/community-notification-popup/community-notification-popup.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
@@ -16,6 +17,7 @@ describe('CommunityNotificationPopupComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [CommunityNotificationPopupComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [IonicModule, RouterTestingModule, TranslateModule.forRoot()],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),

--- a/interfaces/IBF-dashboard/src/app/components/export-view/export-view.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/export-view/export-view.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
@@ -15,6 +16,7 @@ describe('ExportViewComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExportViewComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [IonicModule, RouterTestingModule],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),

--- a/interfaces/IBF-dashboard/src/app/components/ibf-guide-button/ibf-guide-button.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/ibf-guide-button/ibf-guide-button.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
@@ -16,6 +17,7 @@ describe('IbfGuideButtonComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [IbfGuideButtonComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [IonicModule, RouterTestingModule, TranslateModule.forRoot()],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),

--- a/interfaces/IBF-dashboard/src/app/components/login-form/login-form.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/login-form/login-form.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -18,6 +19,7 @@ describe('LoginFormComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [LoginFormComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [
         IonicModule,
         FormsModule,

--- a/interfaces/IBF-dashboard/src/app/components/user-state/user-state.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/user-state/user-state.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
@@ -16,6 +17,7 @@ describe('UserStateComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [UserStateComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [IonicModule, RouterTestingModule, TranslateModule.forRoot()],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),


### PR DESCRIPTION
## Describe your changes

Removes warnings in frontend tests.

## Notes for the reviewer

I noticed 2 tests are skipped using `xit`. These need to be unskipped and the errors resolved.

