### PR TITLE
ci: extend wait time startup

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -59,11 +59,11 @@ runs:
 
     - name: Wait for IBF API-service to be running
       shell: bash
-      run: timeout 60s sh -c 'until curl http://localhost:3000/api -I; do echo "Waiting for the IBF API-service to be running..."; sleep 1; done'
+      run: timeout 90s sh -c 'until curl http://localhost:3000/api -I; do echo "Waiting for the IBF API-service to be running..."; sleep 1; done'
 
     - name: Wait for IBF dashboard to be running
       shell: bash
-      run: timeout 60s sh -c 'until curl http://localhost:4200 -I; do echo "Waiting for the IBF dashboard to be running..."; sleep 1; done'
+      run: timeout 90s sh -c 'until curl http://localhost:4200 -I; do echo "Waiting for the IBF dashboard to be running..."; sleep 1; done'
 
     - name: Run end-to-end tests
       shell: bash

--- a/.github/actions/integration/action.yml
+++ b/.github/actions/integration/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Wait for IBF API-service to be running
       shell: bash
-      run: timeout 60s sh -c 'until curl http://localhost:3000/api -I; do echo "Waiting for the IBF API-service to be running..."; sleep 1; done'
+      run: timeout 90s sh -c 'until curl http://localhost:3000/api -I; do echo "Waiting for the IBF API-service to be running..."; sleep 1; done'
 
     - name: Run integration tests
       shell: bash


### PR DESCRIPTION
## Describe your changes

Extend waiting time from 60s to 90s, as it seems e2e and integration tests are failing at that step and when I open the docker logs, they run until almost but not completely the end (the line saying 'Nest application successfully started').

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

1. Any helpful instructions or clarifications...

