### PR TITLE
Add e2e test for default map checkboxes

### DIFF
--- a/interfaces/IBF-dashboard/src/app/services/point-marker.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/point-marker.service.ts
@@ -145,7 +145,7 @@ export class PointMarkerService {
     const markerInstance = marker(markerLatLng, {
       title: markerTitle,
       icon: markerIcon ? icon(markerIcon) : divIcon(),
-      alt: 'glofas-station-marker',
+      alt: 'Glofas stations',
       zIndexOffset: 700,
     });
     markerInstance.bindPopup(
@@ -247,7 +247,7 @@ export class PointMarkerService {
     const markerInstance = marker(markerLatLng, {
       title: markerTitle,
       icon: icon(LEAFLET_MARKER_ICON_OPTIONS_RED_CROSS_BRANCH),
-      alt: 'red-cross-branch-marker',
+      alt: 'Red Cross branches',
     });
     markerInstance.bindPopup(this.createMarkerRedCrossPopup(markerProperties));
     markerInstance.on(

--- a/tests/e2e/tests/Map/DefaultFloodMapLayerCheckboxes.spec.ts
+++ b/tests/e2e/tests/Map/DefaultFloodMapLayerCheckboxes.spec.ts
@@ -14,6 +14,7 @@ import {
 import LoginPage from '../../Pages/LoginPage';
 
 let accessToken: string;
+let checkedLayers;
 
 test.beforeEach(async ({ page }) => {
   // Login
@@ -37,8 +38,8 @@ test.beforeEach(async ({ page }) => {
 
 test(
   qase(
-    28,
-    '[No-trigger] GloFAS stations markers should be visible on "Legend", "Layer" and "Map"',
+    32,
+    "[No Trigger] Conditional check for (default) map layer's checkboxes (Flood)",
   ),
   async ({ page }) => {
     const dashboard = new DashboardPage(page);
@@ -53,19 +54,21 @@ test(
     });
     // Wait for the page to load
     await dashboard.waitForLoaderToDisappear();
-
     await map.mapComponentIsVisible();
-    await map.isLegendOpen({ legendOpen: true });
-    await map.isLayerMenuOpen({ layerMenuOpen: false });
-    await map.clickLayerMenu();
-    await map.verifyLayerCheckboxCheckedByName({
-      layerName: 'Glofas stations',
-    });
-    await map.assertLegendElementIsVisible({
-      legendComponentName: 'GloFAS No action',
-    });
 
-    // GloFAS layer should be visible by default
-    await map.gloFASMarkersAreVisible();
+    // Open the layer menu
+    // await map.isLayerMenuOpen({ layerMenuOpen: false });
+    // await map.clickLayerMenu();
+    // await map.isLayerMenuOpen({ layerMenuOpen: true });
+    await map.clickLayerCheckbox({ layerName: 'Red Cross branches' });
+
+    // Check if the default layers are visible
+    checkedLayers = await map.returnLayerCheckedCheckboxes();
+    console.log('checkedLayers: ', checkedLayers);
+    if (checkedLayers) {
+      await map.validateLayersAreVisibleByName({ layerNames: checkedLayers });
+    } else {
+      throw new Error('No layers are visible');
+    }
   },
 );


### PR DESCRIPTION
## Describe your changes

Adds E2E test for default checked checkboxes it may either be high level or array can be passed to validate the conditions based on disaster type or trigger/no-trigger mode. For now I kept it high level but it is open for discussion

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review


