### PR TITLE
fix: only show RP if > 0 + linting fixes

### DIFF
--- a/interfaces/IBF-dashboard/eslint.config.js
+++ b/interfaces/IBF-dashboard/eslint.config.js
@@ -155,7 +155,7 @@ module.exports = tseslint.config(
       '@angular-eslint/template/mouse-events-have-key-events': 'warn',
       '@angular-eslint/template/alt-text': 'warn',
       '@angular-eslint/template/elements-content': 'warn',
-      '@angular-eslint/template/i18n': 'warn',
+      '@angular-eslint/template/i18n': 'off', // 'warn' caused automatic changes that broke the code
 
       //'@angular-eslint/template/i18n': [
       //  'error',

--- a/interfaces/IBF-dashboard/src/app/components/leaflet-popup/glofas-station-popup-content/glofas-station-popup-content.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/leaflet-popup/glofas-station-popup-content/glofas-station-popup-content.component.html
@@ -12,7 +12,7 @@
         style="cursor: default"
         ><ion-icon name="information-circle-outline"></ion-icon></span
     ></strong>
-    @if (data?.station?.dynamicData?.forecastReturnPeriod) {
+    @if (data?.station?.dynamicData?.forecastReturnPeriod > 0) {
       <br />
       {{
         'map-popups.glofas-station.forecast-return'

--- a/interfaces/IBF-dashboard/src/app/components/leaflet-popup/glofas-station-popup-content/glofas-station-popup-content.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/leaflet-popup/glofas-station-popup-content/glofas-station-popup-content.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { EapAlertClass, EapAlertClasses } from '../../../models/country.model';
-import { Station } from '../../../models/poi.model';
-import { LeadTime } from '../../../types/lead-time';
+import { EapAlertClass, EapAlertClasses } from 'src/app/models/country.model';
+import { Station } from 'src/app/models/poi.model';
+import { LeadTime } from 'src/app/types/lead-time';
 
 @Component({
   selector: 'app-glofas-station-popup-content',
@@ -73,7 +73,7 @@ export class GlofasStationPopupContentComponent implements OnInit {
   public addComma = (n) => Math.round(n).toLocaleString('en-US');
 
   public getLeadTimeString(): string {
-    if (!this.data || !this.data?.leadTime) {
+    if (!this.data?.leadTime) {
       return '';
     }
 

--- a/interfaces/IBF-dashboard/src/app/models/poi.model.ts
+++ b/interfaces/IBF-dashboard/src/app/models/poi.model.ts
@@ -2,8 +2,14 @@
 export class Station {
   stationName: string;
   stationCode: string;
-  /* eslint-disable  @typescript-eslint/no-explicit-any */
-  dynamicData?: any;
+  dynamicData?: StationDynamicData;
+}
+
+export class StationDynamicData {
+  forecastLevel: number;
+  triggerLevel: number;
+  forecastReturnPeriod: number;
+  eapAlertClass: string;
 }
 
 export class TyphoonTrackPoint {


### PR DESCRIPTION
## Describe your changes

Resolves [issue 1798](https://github.com/rodekruis/IBF-system/issues/1798)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

1. The issue was that forecastReturnPeriod could have value '0' (as string), and was therefore not blocked by the current 'falsy' check. Adding the '>0' works if forecastReturnPeriod is number or string. (but good to check)
2. Also addressed some of the eslint warnings of the touched files.

