### PR TITLE
docs: add certbot steps to VM SETUP doc

### DIFF
--- a/docs/VM_SETUP.md
+++ b/docs/VM_SETUP.md
@@ -75,6 +75,10 @@
        - `service nginx restart` to restart nginx with new configuration
        - `systemctl enable nginx` to start nginx on VM reboot
        - `service nginx status` to verify
+       - Install SSL certificate using [certbot](https://certbot.eff.org/instructions?ws=nginx&os=ubuntufocal)
+         - `snap install --classic certbot`
+         - `ln -s /snap/bin/certbot /usr/bin/certbot`
+         - `certbot --nginx`
    11. `source tools/deploy.sh`
 
 4. Load base data


### PR DESCRIPTION
## Describe your changes

This PR is a follow-up on #1602 based on dev experience in the demo VM.

I updated the VM SETUP doc with steps to install the SSL certificate.

## Notes for the reviewer

These are the commands I ran on the demo VM. These are valid today but can change so I also included the [link to the source](https://certbot.eff.org/instructions?ws=nginx&os=ubuntufocal) of these commands. [Certbot](https://certbot.eff.org/) reads the existing nginx config and reconfigures it to include SSL certificates from [LetsEncrypt](https://letsencrypt.org/).