### PR TITLE
Add e2e test for default markers in triggered floods

### DIFF
--- a/tests/e2e/tests/Map/DefaultLegendLayersInTriggeredFlood.spec.ts
+++ b/tests/e2e/tests/Map/DefaultLegendLayersInTriggeredFlood.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 import DashboardPage from 'Pages/DashboardPage';
 import MapComponent from 'Pages/MapComponent';
 import UserStateComponent from 'Pages/UserStateComponent';
@@ -53,7 +53,11 @@ test(
 
     await map.mapComponentIsVisible();
     await map.isLegendOpen({ legendOpen: true });
-    const legendLayers = await map.returnLayerCheckedCheckboxes();
-    expect(legendLayers).toEqual(['Flood extent', 'Exposed population']);
+    await map.assertLegendElementIsVisible({
+      legendComponentName: 'Flood extent',
+    });
+    await map.assertLegendElementIsVisible({
+      legendComponentName: 'Exposed population',
+    });
   },
 );

--- a/tests/e2e/tests/Map/DefaultLegendLayersInTriggeredFlood.spec.ts
+++ b/tests/e2e/tests/Map/DefaultLegendLayersInTriggeredFlood.spec.ts
@@ -1,0 +1,60 @@
+import { test } from '@playwright/test';
+import DashboardPage from 'Pages/DashboardPage';
+import MapComponent from 'Pages/MapComponent';
+import UserStateComponent from 'Pages/UserStateComponent';
+import { qase } from 'playwright-qase-reporter';
+import { TriggerDataSet } from 'testData/testData.enum';
+
+import { FloodsScenario } from '../../../../services/API-service/src/scripts/enum/mock-scenario.enum';
+import {
+  getAccessToken,
+  mockFloods,
+  resetDB,
+} from '../../helpers/utility.helper';
+import LoginPage from '../../Pages/LoginPage';
+
+let accessToken: string;
+
+test.beforeEach(async ({ page }) => {
+  // Login
+  const loginPage = new LoginPage(page);
+  accessToken = await getAccessToken();
+  await resetDB(accessToken);
+
+  // We should maybe create one mock for all different disaster types for now we can just use floods
+  await mockFloods(
+    FloodsScenario.Trigger,
+    TriggerDataSet.CountryCode,
+    accessToken,
+  );
+
+  await page.goto('/');
+  await loginPage.login(TriggerDataSet.UserMail, TriggerDataSet.UserPassword);
+});
+// https://app.qase.io/project/IBF?previewMode=side&suite=3&tab=&case=37
+test(
+  qase(
+    37,
+    '[Trigger] Map layer: "Flood extent" and "Exposed population" should be active by default',
+  ),
+  async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    const userState = new UserStateComponent(page);
+    const map = new MapComponent(page);
+
+    // Navigate to disaster type the data was mocked for
+    await dashboard.navigateToFloodDisasterType();
+    // Assertions
+    await userState.headerComponentIsVisible({
+      countryName: TriggerDataSet.CountryName,
+    });
+    // Wait for the page to load
+    await dashboard.waitForLoaderToDisappear();
+
+    await map.mapComponentIsVisible();
+    await map.isLegendOpen({ legendOpen: true });
+    await map.validateLayersAreVisibleByName({
+      layerNames: ['Flood extent', 'Exposed population'],
+    });
+  },
+);

--- a/tests/e2e/tests/Map/DefaultLegendLayersInTriggeredFlood.spec.ts
+++ b/tests/e2e/tests/Map/DefaultLegendLayersInTriggeredFlood.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import DashboardPage from 'Pages/DashboardPage';
 import MapComponent from 'Pages/MapComponent';
 import UserStateComponent from 'Pages/UserStateComponent';
@@ -53,8 +53,7 @@ test(
 
     await map.mapComponentIsVisible();
     await map.isLegendOpen({ legendOpen: true });
-    await map.validateLayersAreVisibleByName({
-      layerNames: ['Flood extent', 'Exposed population'],
-    });
+    const legendLayers = await map.returnLayerCheckedCheckboxes();
+    expect(legendLayers).toEqual(['Flood extent', 'Exposed population']);
   },
 );

--- a/tests/e2e/tests/Map/DefaultMarkersVisibleFloodsTrigger.spec.ts
+++ b/tests/e2e/tests/Map/DefaultMarkersVisibleFloodsTrigger.spec.ts
@@ -67,15 +67,5 @@ test(
       glosfasStationStatus: 'glofas-station-max-trigger',
       isVisible: true,
     });
-    // At least one orange GloFAS station should be visible by default in trigger mode
-    await map.gloFASMarkersAreVisibleByWarning({
-      glosfasStationStatus: 'glofas-station-med-trigger',
-      isVisible: true,
-    });
-    // At least one yellow GloFAS station should be visible by default in trigger mode
-    await map.gloFASMarkersAreVisibleByWarning({
-      glosfasStationStatus: 'glofas-station-min-trigger',
-      isVisible: true,
-    });
   },
 );

--- a/tests/e2e/tests/Map/DefaultMarkersVisibleFloodsTrigger.spec.ts
+++ b/tests/e2e/tests/Map/DefaultMarkersVisibleFloodsTrigger.spec.ts
@@ -1,0 +1,81 @@
+import { test } from '@playwright/test';
+import DashboardPage from 'Pages/DashboardPage';
+import MapComponent from 'Pages/MapComponent';
+import UserStateComponent from 'Pages/UserStateComponent';
+import { qase } from 'playwright-qase-reporter';
+import { TriggerDataSet } from 'testData/testData.enum';
+
+import { FloodsScenario } from '../../../../services/API-service/src/scripts/enum/mock-scenario.enum';
+import {
+  getAccessToken,
+  mockFloods,
+  resetDB,
+} from '../../helpers/utility.helper';
+import LoginPage from '../../Pages/LoginPage';
+
+let accessToken: string;
+
+test.beforeEach(async ({ page }) => {
+  // Login
+  const loginPage = new LoginPage(page);
+  accessToken = await getAccessToken();
+  await resetDB(accessToken);
+
+  // We should maybe create one mock for all different disaster types for now we can just use floods
+  await mockFloods(
+    FloodsScenario.Trigger,
+    TriggerDataSet.CountryCode,
+    accessToken,
+  );
+
+  await page.goto('/');
+  await loginPage.login(TriggerDataSet.UserMail, TriggerDataSet.UserPassword);
+});
+
+test(
+  qase(
+    38,
+    '[Trigger] At least one red/orange/yellow GloFAS station should be visible',
+  ),
+  async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    const userState = new UserStateComponent(page);
+    const map = new MapComponent(page);
+
+    // Navigate to disaster type the data was mocked for
+    await dashboard.navigateToFloodDisasterType();
+    // Assertions
+    await userState.headerComponentIsVisible({
+      countryName: TriggerDataSet.CountryName,
+    });
+    // Wait for the page to load
+    await dashboard.waitForLoaderToDisappear();
+
+    await map.mapComponentIsVisible();
+    await map.isLegendOpen({ legendOpen: true });
+    await map.isLayerMenuOpen({ layerMenuOpen: false });
+    await map.clickLayerMenu();
+    await map.verifyLayerCheckboxCheckedByName({
+      layerName: 'Glofas stations',
+    });
+    await map.assertLegendElementIsVisible({
+      legendComponentName: 'GloFAS No action',
+    });
+
+    // At least one red/orange/yellow GloFAS station should be visible by default in trigger mode
+    await map.gloFASMarkersAreVisibleByWarning({
+      glosfasStationStatus: 'glofas-station-max-trigger',
+      isVisible: true,
+    });
+    // At least one orange GloFAS station should be visible by default in trigger mode
+    await map.gloFASMarkersAreVisibleByWarning({
+      glosfasStationStatus: 'glofas-station-med-trigger',
+      isVisible: true,
+    });
+    // At least one yellow GloFAS station should be visible by default in trigger mode
+    await map.gloFASMarkersAreVisibleByWarning({
+      glosfasStationStatus: 'glofas-station-min-trigger',
+      isVisible: true,
+    });
+  },
+);


### PR DESCRIPTION
## Describe your changes

Adds E2E test for default markers in floods trigger mode (Red, Orange and Yellow).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review
