### PR TITLE
Feat.add e2e test header colour in trigger is purpule

### DIFF
--- a/interfaces/IBF-dashboard/src/app/pages/dashboard/dashboard.page.html
+++ b/interfaces/IBF-dashboard/src/app/pages/dashboard/dashboard.page.html
@@ -64,7 +64,11 @@
   </ion-content>
 </ion-menu>
 
-<div id="ibf-dashboard-interface" class="ibf-dashboard-interface">
+<div
+  id="ibf-dashboard-interface"
+  data-testid="ibf-dashboard-interface"
+  class="ibf-dashboard-interface"
+>
   <ion-header
     class="ion-no-border"
     style="border-bottom: 1px solid var(--ion-color-ibf-no-alert-primary)"

--- a/tests/e2e/Pages/AggregatesComponent.ts
+++ b/tests/e2e/Pages/AggregatesComponent.ts
@@ -130,6 +130,12 @@ class AggregatesComponent extends DashboardPage {
 
     return eventsNumber ? parseInt(eventsNumber[0], 10) : null;
   }
+
+  async validateColourOfAggregatesHeader() {
+    const actionHeaderText = await this.aggregatesTitleHeader;
+    const headerColour = await actionHeaderText.getAttribute('style');
+    console.log('headerColour: ', headerColour);
+  }
 }
 
 export default AggregatesComponent;

--- a/tests/e2e/Pages/AggregatesComponent.ts
+++ b/tests/e2e/Pages/AggregatesComponent.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 import { Locator, Page } from 'playwright';
+import { IbfStyles } from 'testData/styles.enum';
 import { EnglishTranslations } from 'testData/translations.enum';
 
 import DashboardPage from './DashboardPage';
@@ -24,6 +25,7 @@ class AggregatesComponent extends DashboardPage {
   readonly popoverLayer: Locator;
   readonly layerInfoPopoverTitle: Locator;
   readonly layerInfoPopoverContent: Locator;
+  readonly ibfDashboardInterface: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -46,6 +48,7 @@ class AggregatesComponent extends DashboardPage {
     this.popoverLayer = this.page.getByTestId('disclaimer-popover-layer');
     this.layerInfoPopoverTitle = this.page.getByTestId('layer-info-title');
     this.layerInfoPopoverContent = this.page.getByTestId('layer-info-content');
+    this.ibfDashboardInterface = page.getByTestId('ibf-dashboard-interface');
   }
 
   async aggregateComponentIsVisible() {
@@ -131,10 +134,19 @@ class AggregatesComponent extends DashboardPage {
     return eventsNumber ? parseInt(eventsNumber[0], 10) : null;
   }
 
-  async validateColourOfAggregatesHeader() {
-    const actionHeaderText = await this.aggregatesTitleHeader;
-    const headerColour = await actionHeaderText.getAttribute('style');
-    console.log('headerColour: ', headerColour);
+  async validateColorOfAggregatesHeaderByClass({
+    isTrigger = false,
+  }: {
+    isTrigger?: boolean;
+  }) {
+    const actionHeaderText = this.ibfDashboardInterface;
+    const headerColour = await actionHeaderText.getAttribute('class');
+
+    if (isTrigger) {
+      expect(headerColour).toContain(IbfStyles.trigger);
+    } else {
+      expect(headerColour).toContain(IbfStyles.noTrigger);
+    }
   }
 }
 

--- a/tests/e2e/testData/styles.enum.ts
+++ b/tests/e2e/testData/styles.enum.ts
@@ -1,0 +1,4 @@
+export enum IbfStyles {
+  noTrigger = 'no-alert',
+  trigger = 'trigger-alert',
+}

--- a/tests/e2e/tests/AggregatesSection/AggregatesHeaderShouldBePurpleInTriggerState.spec.ts
+++ b/tests/e2e/tests/AggregatesSection/AggregatesHeaderShouldBePurpleInTriggerState.spec.ts
@@ -44,6 +44,7 @@ test(qase(40, '[Trigger] header colour is purple'), async ({ page }) => {
   });
 
   // Validate that the aggregates header is purple by class
-  // ASK ANDREA WHICH IS THE NAME OF THE BACKGROUND COLOR CLASS!!!
-  await aggregates.validateColourOfAggregatesHeader();
+  await aggregates.validateColorOfAggregatesHeaderByClass({
+    isTrigger: true,
+  });
 });

--- a/tests/e2e/tests/AggregatesSection/AggregatesHeaderShouldBePurpleInTriggerState.spec.ts
+++ b/tests/e2e/tests/AggregatesSection/AggregatesHeaderShouldBePurpleInTriggerState.spec.ts
@@ -1,0 +1,49 @@
+import { test } from '@playwright/test';
+import AggregatesComponent from 'Pages/AggregatesComponent';
+import DashboardPage from 'Pages/DashboardPage';
+import UserStateComponent from 'Pages/UserStateComponent';
+import { qase } from 'playwright-qase-reporter';
+import { TriggerDataSet } from 'testData/testData.enum';
+
+import {
+  getAccessToken,
+  mockFloods,
+  resetDB,
+} from '../../helpers/utility.helper';
+import LoginPage from '../../Pages/LoginPage';
+
+let accessToken: string;
+
+test.beforeEach(async ({ page }) => {
+  // Login
+  const loginPage = new LoginPage(page);
+
+  accessToken = await getAccessToken();
+  await resetDB(accessToken);
+  // We should maybe create one mock for all different disaster types for now we can just use floods
+  await mockFloods(
+    TriggerDataSet.TriggerScenario,
+    TriggerDataSet.CountryCode,
+    accessToken,
+  );
+
+  await page.goto('/');
+  await loginPage.login(TriggerDataSet.UserMail, TriggerDataSet.UserPassword);
+});
+
+test(qase(40, '[Trigger] header colour is purple'), async ({ page }) => {
+  const aggregates = new AggregatesComponent(page);
+  const dashboard = new DashboardPage(page);
+  const userState = new UserStateComponent(page);
+
+  // Navigate to disaster type the data was mocked for
+  await dashboard.navigateToFloodDisasterType();
+  // Assertions
+  await userState.headerComponentIsVisible({
+    countryName: TriggerDataSet.CountryName,
+  });
+
+  // Validate that the aggregates header is purple by class
+  // ASK ANDREA WHICH IS THE NAME OF THE BACKGROUND COLOR CLASS!!!
+  await aggregates.validateColourOfAggregatesHeader();
+});

--- a/tests/e2e/tests/AggregatesSection/AggregatesHeaderShouldBePurpleInTriggerState.spec.ts
+++ b/tests/e2e/tests/AggregatesSection/AggregatesHeaderShouldBePurpleInTriggerState.spec.ts
@@ -30,7 +30,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto('/');
   await loginPage.login(TriggerDataSet.UserMail, TriggerDataSet.UserPassword);
 });
-
+// https://app.qase.io/project/IBF?previewMode=side&suite=7&case=40
 test(qase(40, '[Trigger] header colour is purple'), async ({ page }) => {
   const aggregates = new AggregatesComponent(page);
   const dashboard = new DashboardPage(page);


### PR DESCRIPTION
## Describe your changes

[AB#32403](https://dev.azure.com/redcrossnl/9e7ca3cc-bb97-4471-a25c-fd9787af0fe8/_workitems/edit/32403)

Adds test for checking if correct colour is assigned to Aggregates by class.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review

## Note for reviewer:

The idea was to catch the full colour code but I added a bit simpler solution without digging into the "color" value itself. Let me know if this is sufficient.

notes from my discussion with Gulfaraz:

```

const dashboardElement = document.getElementById('ibf-dashboard-interface');

.no-alert [data-test].aggregates-header === #758399
.no-alert [data-test].aggregates-footer === #758399

.trigger-alert [data-test].aggregates-header === #adasda
.trigger-alert [data-test].aggregates-footer === #adasda

{
trigger-color:#adasda
no-alert-color: #asdasd
}

```

