### PR TITLE
refactor: make e2e code somewhat disaster-type agnostic AB#32759

### DIFF
--- a/tests/e2e/Pages/ChatComponent.ts
+++ b/tests/e2e/Pages/ChatComponent.ts
@@ -4,10 +4,13 @@ import * as os from 'os';
 import { Locator, Page } from 'playwright';
 
 import EnglishTranslations from '../../../interfaces/IBF-dashboard/src/assets/i18n/en.json';
+import { NoTriggerDataSet } from '../testData/testData.enum';
 import DashboardPage from './DashboardPage';
 
 const chatDialogueContentWelcomeNoTrigger =
-  EnglishTranslations['chat-component'].floods['no-event-no-trigger'].welcome;
+  EnglishTranslations['chat-component'][NoTriggerDataSet.DisasterType][
+    'no-event-no-trigger'
+  ].welcome;
 const chatDialogueWarnLabel =
   EnglishTranslations['chat-component'].common['warn-label'].message;
 const eventTooltipContent =

--- a/tests/e2e/Pages/DashboardPage.ts
+++ b/tests/e2e/Pages/DashboardPage.ts
@@ -40,25 +40,24 @@ class DashboardPage {
     return Math.floor(Math.random() * (max - min + 1)) + min;
   }
 
-  async navigateToFloodDisasterType() {
+  async navigateToDisasterType(disasterType: string) {
     await this.page.waitForSelector(
-      '[data-testid=disaster-type-button-floods]',
+      `[data-testid=disaster-type-button-${disasterType}]`,
     );
-    await this.floodIcon.click();
-  }
-
-  async navigateToHeavyRainDisasterType() {
-    await this.page.waitForSelector(
-      '[data-testid=disaster-type-button-heavy-rain]',
-    );
-    await this.heavyRainIcon.click();
-  }
-
-  async navigateToDroughtDisasterType() {
-    await this.page.waitForSelector(
-      '[data-testid=disaster-type-button-drought]',
-    );
-    await this.droughtIcon.click();
+    switch (disasterType) {
+      case 'floods':
+        await this.floodIcon.click();
+        break;
+      case 'heavy-rain':
+        await this.heavyRainIcon.click();
+        break;
+      case 'drought':
+        await this.droughtIcon.click();
+        break;
+      default:
+        console.log('Invalid disaster type');
+        break;
+    }
   }
 
   async waitForLoaderToDisappear() {

--- a/tests/e2e/helpers/utility.helper.ts
+++ b/tests/e2e/helpers/utility.helper.ts
@@ -43,13 +43,14 @@ export function resetDB(accessToken: string): Promise<request.Response> {
     });
 }
 
-export function mockFloods(
+export function mockData(
+  disasterType: string,
   scenario: string,
   countryCodeISO3: string,
   accessToken: string,
 ): Promise<request.Response> {
   return getServer()
-    .post('/mock/floods')
+    .post(`/mock/${disasterType}`)
     .set('Authorization', `Bearer ${accessToken}`)
     .query({ isApiTest: true })
     .send({

--- a/tests/e2e/testData/testData.enum.ts
+++ b/tests/e2e/testData/testData.enum.ts
@@ -1,5 +1,6 @@
 export enum NoTriggerDataSet {
   NoTriggerScenario = 'no-trigger',
+  DisasterType = 'floods', // floods/drought
   CountryCode = 'UGA',
   CountryName = 'Uganda',
   UserMail = 'uganda@redcross.nl',
@@ -10,6 +11,7 @@ export enum NoTriggerDataSet {
 
 export enum TriggerDataSet {
   TriggerScenario = 'trigger',
+  DisasterType = 'floods', // floods/drought
   CountryCode = 'UGA',
   CountryName = 'Uganda',
   UserMail = 'uganda@redcross.nl',

--- a/tests/e2e/tests/AggregatesComponent/AggregateComponentButtonClick.ts
+++ b/tests/e2e/tests/AggregatesComponent/AggregateComponentButtonClick.ts
@@ -3,7 +3,11 @@ import { qase } from 'playwright-qase-reporter';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(13, 'Info button(s) should be clickable'),
     {
@@ -21,7 +25,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await aggregates.aggregateComponentIsVisible();
       await aggregates.validatesAggregatesInfoButtons();

--- a/tests/e2e/tests/AggregatesComponent/AggregateComponentEventCount.ts
+++ b/tests/e2e/tests/AggregatesComponent/AggregateComponentEventCount.ts
@@ -4,7 +4,11 @@ import { TriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(39, 'Number of events should be non-zero'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: TriggerDataSet.CountryName,

--- a/tests/e2e/tests/AggregatesComponent/AggregateComponentHeaderColour.ts
+++ b/tests/e2e/tests/AggregatesComponent/AggregateComponentHeaderColour.ts
@@ -4,7 +4,11 @@ import { TriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(40, 'Header colour should be purple'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: TriggerDataSet.CountryName,

--- a/tests/e2e/tests/AggregatesComponent/AggregateComponentTitleHover.ts
+++ b/tests/e2e/tests/AggregatesComponent/AggregateComponentTitleHover.ts
@@ -3,7 +3,11 @@ import { qase } from 'playwright-qase-reporter';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(12, 'Title should change based on hovered map district'),
     {
@@ -21,7 +25,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await aggregates.aggregateComponentIsVisible();
       await map.clickLayerCheckbox({ layerName: 'Glofas stations' });

--- a/tests/e2e/tests/AggregatesComponent/AggregatesComponentVisible.ts
+++ b/tests/e2e/tests/AggregatesComponent/AggregatesComponentVisible.ts
@@ -3,7 +3,11 @@ import { qase } from 'playwright-qase-reporter';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(6, 'Aggregates component elements should be visible'),
     {
@@ -21,7 +25,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await aggregates.aggregateComponentIsVisible();
       await aggregates.aggregatesAlementsDisplayedInNoTrigger();

--- a/tests/e2e/tests/ChatComponent/ChatComponentButtonClick.ts
+++ b/tests/e2e/tests/ChatComponent/ChatComponentButtonClick.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(11, 'Action buttons should be clickable'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,
@@ -32,7 +36,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       await chat.clickAndAssertGuideButton();
       await chat.clickAndAssertExportViewButton();
       await chat.clickAndAssertTriggerLogButton({
-        url: `/log?countryCodeISO3=${NoTriggerDataSet.CountryCode}&disasterType=floods`,
+        url: `/log?countryCodeISO3=${NoTriggerDataSet.CountryCode}&disasterType=${disasterType}`,
       });
     },
   );

--- a/tests/e2e/tests/ChatComponent/ChatComponentEventClick.ts
+++ b/tests/e2e/tests/ChatComponent/ChatComponentEventClick.ts
@@ -4,7 +4,11 @@ import { TriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(44, 'Show prediction button should be clickable'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: TriggerDataSet.CountryName,

--- a/tests/e2e/tests/ChatComponent/ChatComponentEventCount.ts
+++ b/tests/e2e/tests/ChatComponent/ChatComponentEventCount.ts
@@ -4,7 +4,11 @@ import { TriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(
       43,
@@ -25,7 +29,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: TriggerDataSet.CountryName,

--- a/tests/e2e/tests/ChatComponent/ChatComponentInfoPopover.ts
+++ b/tests/e2e/tests/ChatComponent/ChatComponentInfoPopover.ts
@@ -4,7 +4,11 @@ import { TriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(45, 'Info icon should open popover on click'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: TriggerDataSet.CountryName,

--- a/tests/e2e/tests/ChatComponent/ChatComponentVisible.ts
+++ b/tests/e2e/tests/ChatComponent/ChatComponentVisible.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(5, 'Chat component elements should be visible'),
     {
@@ -21,7 +25,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
         throw new Error('pages and components not found');
       }
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,

--- a/tests/e2e/tests/DashboardPage/DashboardPageVisible.ts
+++ b/tests/e2e/tests/DashboardPage/DashboardPageVisible.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(1, 'Dashboard page elements should be visible'),
     {
@@ -15,7 +19,13 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
     },
     async () => {
       const { dashboard } = pages;
-      const { chat, userState, aggregates, map, disasterType } = components;
+      const {
+        chat,
+        userState,
+        aggregates,
+        map,
+        disasterType: disasterTypeComponent,
+      } = components;
 
       if (
         !dashboard ||
@@ -23,17 +33,17 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
         !userState ||
         !aggregates ||
         !map ||
-        !disasterType
+        !disasterTypeComponent
       ) {
         throw new Error('pages and components not found');
       }
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,
       });
-      await disasterType.topBarComponentIsVisible();
+      await disasterTypeComponent.topBarComponentIsVisible();
       await chat.chatColumnIsVisibleForNoTriggerState({
         firstName: NoTriggerDataSet.firstName,
         lastName: NoTriggerDataSet.lastName,

--- a/tests/e2e/tests/DisasterTypeComponent/DisasterTypeComponentSelect.ts
+++ b/tests/e2e/tests/DisasterTypeComponent/DisasterTypeComponentSelect.ts
@@ -25,19 +25,19 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate between disaster types no matter the mock data
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType('floods');
       await userState.headerComponentDisplaysCorrectDisasterType({
         countryName: NoTriggerDataSet.CountryName,
         disasterName: 'floods',
       });
 
-      await dashboard.navigateToDroughtDisasterType();
+      await dashboard.navigateToDisasterType('drought');
       await userState.headerComponentDisplaysCorrectDisasterType({
         countryName: NoTriggerDataSet.CountryName,
         disasterName: 'drought',
       });
 
-      await dashboard.navigateToHeavyRainDisasterType();
+      await dashboard.navigateToDisasterType('heavy-rain');
       await userState.headerComponentDisplaysCorrectDisasterType({
         countryName: NoTriggerDataSet.CountryName,
         disasterName: 'heavy-rain',

--- a/tests/e2e/tests/DisasterTypeComponent/DisasterTypeComponentVisible.ts
+++ b/tests/e2e/tests/DisasterTypeComponent/DisasterTypeComponentVisible.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(4, 'Disaster type component elements should be visible'),
     {
@@ -15,20 +19,20 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
     },
     async () => {
       const { dashboard } = pages;
-      const { userState, disasterType } = components;
+      const { userState, disasterType: disasterTypeComponent } = components;
 
-      if (!dashboard || !userState || !disasterType) {
+      if (!dashboard || !userState || !disasterTypeComponent) {
         throw new Error('pages and components not found');
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,
       });
-      await disasterType.topBarComponentIsVisible();
-      await disasterType.allDisasterTypeElementsArePresent();
+      await disasterTypeComponent.topBarComponentIsVisible();
+      await disasterTypeComponent.allDisasterTypeElementsArePresent();
     },
   );
 };

--- a/tests/e2e/tests/MapComponent/MapComponentAlertThreshold.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentAlertThreshold.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(29, 'alert_threshold should be visible'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,

--- a/tests/e2e/tests/MapComponent/MapComponentFloodExtent.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentFloodExtent.ts
@@ -4,7 +4,11 @@ import { TriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(35, 'flood_extent legend should be visible'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: TriggerDataSet.CountryName,

--- a/tests/e2e/tests/MapComponent/MapComponentGloFASStations.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentGloFASStations.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(28, 'glofas_stations should be visible'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,

--- a/tests/e2e/tests/MapComponent/MapComponentGloFASStationsTrigger.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentGloFASStationsTrigger.ts
@@ -4,7 +4,11 @@ import { TriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(38, 'Trigger GloFAS station(s) should be visible'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: TriggerDataSet.CountryName,

--- a/tests/e2e/tests/MapComponent/MapComponentGloFASStationsWarning.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentGloFASStationsWarning.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(31, 'Trigger GloFAS station(s) should not be visible'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,

--- a/tests/e2e/tests/MapComponent/MapComponentInfoPopover.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentInfoPopover.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(33, 'Info icon should open popover on click'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,

--- a/tests/e2e/tests/MapComponent/MapComponentInteractive.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentInteractive.ts
@@ -7,7 +7,11 @@ import { Components, Pages } from '../../helpers/interfaces';
 // REFACTOR: break down the test into separate tests
 // for legend, layer menu, and red cross branches
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(7, 'Map component should be interactive'),
     {
@@ -25,7 +29,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,

--- a/tests/e2e/tests/MapComponent/MapComponentLayersDefault.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentLayersDefault.ts
@@ -4,7 +4,11 @@ import { TriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(37, 'flood_extent and exposed_population should be active by default'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: TriggerDataSet.CountryName,

--- a/tests/e2e/tests/MapComponent/MapComponentLayersVisible.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentLayersVisible.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(32, 'Map should show active layers'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,

--- a/tests/e2e/tests/MapComponent/MapComponentVisible.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentVisible.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(2, 'Map component elements should be visible'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,

--- a/tests/e2e/tests/ScenarioNoTrigger.spec.ts
+++ b/tests/e2e/tests/ScenarioNoTrigger.spec.ts
@@ -9,7 +9,7 @@ import TimelineComponent from 'Pages/TimelineComponent';
 import UserStateComponent from 'Pages/UserStateComponent';
 import { NoTriggerDataSet } from 'testData/testData.enum';
 
-import { getAccessToken, mockFloods, resetDB } from '../helpers/utility.helper';
+import { getAccessToken, mockData, resetDB } from '../helpers/utility.helper';
 import LoginPage from '../Pages/LoginPage';
 import AggregateComponentButtonClick from './AggregatesComponent/AggregateComponentButtonClick';
 import AggregateComponentTitleHover from './AggregatesComponent/AggregateComponentTitleHover';
@@ -37,6 +37,10 @@ const pages: Partial<Pages> = {};
 const components: Partial<Components> = {};
 
 test.describe('Scenario: No Trigger', () => {
+  const disasterType = NoTriggerDataSet.DisasterType;
+  const countryCodeISO3 = NoTriggerDataSet.CountryCode;
+  const scenario = NoTriggerDataSet.NoTriggerScenario;
+
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
     // Initialize pages and components after sharedPage is assigned
@@ -54,12 +58,7 @@ test.describe('Scenario: No Trigger', () => {
     await resetDB(accessToken);
 
     // Load a mock scenario
-    // We should maybe create one mock for all different disaster types for now we can just use floods
-    await mockFloods(
-      NoTriggerDataSet.NoTriggerScenario,
-      NoTriggerDataSet.CountryCode,
-      accessToken,
-    );
+    await mockData(disasterType, scenario, countryCodeISO3, accessToken);
 
     await page.goto('/');
     // Login into the portal
@@ -78,41 +77,45 @@ test.describe('Scenario: No Trigger', () => {
   });
 
   test.describe('DashboardPage', () => {
-    DashboardPageVisible(pages, components);
+    DashboardPageVisible(pages, components, disasterType);
   });
 
   test.describe('MapComponent', () => {
-    MapComponentVisible(pages, components);
-    MapComponentInteractive(pages, components);
-    MapComponentLayersVisible(pages, components);
-    MapComponentAlertThreshold(pages, components);
-    MapComponentGloFASStations(pages, components);
-    MapComponentGloFASStationsWarning(pages, components);
+    MapComponentVisible(pages, components, disasterType);
+    MapComponentInteractive(pages, components, disasterType);
+    MapComponentLayersVisible(pages, components, disasterType);
+    MapComponentAlertThreshold(pages, components, disasterType);
+    MapComponentGloFASStations(pages, components, disasterType);
+    MapComponentGloFASStationsWarning(pages, components, disasterType);
   });
 
   test.describe('UserStateComponent', () => {
-    UserStateComponentVisible(pages, components);
-    UserStateComponentLogout(pages, components);
+    UserStateComponentVisible(pages, components, disasterType);
+    UserStateComponentLogout(pages, components, disasterType);
   });
 
   test.describe('AggregatesComponent', () => {
-    AggregatesComponentVisible(pages, components);
-    AggregateComponentTitleHover(pages, components);
-    AggregateComponentButtonClick(pages, components);
+    AggregatesComponentVisible(pages, components, disasterType);
+    AggregateComponentTitleHover(pages, components, disasterType);
+    AggregateComponentButtonClick(pages, components, disasterType);
   });
 
   test.describe('ChatComponent', () => {
-    ChatComponentVisible(pages, components);
-    ChatComponentButtonClick(pages, components);
+    ChatComponentVisible(pages, components, disasterType);
+    ChatComponentButtonClick(pages, components, disasterType);
   });
 
   test.describe('DisasterTypeComponent', () => {
-    DisasterTypeComponentVisible(pages, components);
+    DisasterTypeComponentVisible(
+      pages,
+      components,
+      NoTriggerDataSet.DisasterType,
+    );
     DisasterTypeComponentSelect(pages, components);
   });
 
   test.describe('TimelineComponent', () => {
-    TimelineComponentVisible(pages, components);
-    TimelineComponentDisabled(pages, components);
+    TimelineComponentVisible(pages, components, NoTriggerDataSet.DisasterType);
+    TimelineComponentDisabled(pages, components, NoTriggerDataSet.DisasterType);
   });
 });

--- a/tests/e2e/tests/ScenarioTrigger.spec.ts
+++ b/tests/e2e/tests/ScenarioTrigger.spec.ts
@@ -9,7 +9,7 @@ import TimelineComponent from 'Pages/TimelineComponent';
 import UserStateComponent from 'Pages/UserStateComponent';
 import { TriggerDataSet } from 'testData/testData.enum';
 
-import { getAccessToken, mockFloods, resetDB } from '../helpers/utility.helper';
+import { getAccessToken, mockData, resetDB } from '../helpers/utility.helper';
 import LoginPage from '../Pages/LoginPage';
 import AggregateComponentEventCount from './AggregatesComponent/AggregateComponentEventCount';
 import AggregateComponentHeaderColour from './AggregatesComponent/AggregateComponentHeaderColour';
@@ -27,6 +27,10 @@ const pages: Partial<Pages> = {};
 const components: Partial<Components> = {};
 
 test.describe('Scenario: Trigger', () => {
+  const disasterType = TriggerDataSet.DisasterType;
+  const countryCodeISO3 = TriggerDataSet.CountryCode;
+  const scenario = TriggerDataSet.TriggerScenario;
+
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
     // Initialize pages and components after sharedPage is assigned
@@ -44,12 +48,7 @@ test.describe('Scenario: Trigger', () => {
     await resetDB(accessToken);
 
     // Load a mock scenario
-    // We should maybe create one mock for all different disaster types for now we can just use floods
-    await mockFloods(
-      TriggerDataSet.TriggerScenario,
-      TriggerDataSet.CountryCode,
-      accessToken,
-    );
+    await mockData(disasterType, scenario, countryCodeISO3, accessToken);
 
     await page.goto('/');
     // Login into the portal
@@ -68,19 +67,19 @@ test.describe('Scenario: Trigger', () => {
   });
 
   test.describe('MapComponent', () => {
-    MapComponentLayersDefault(pages, components);
-    MapComponentFloodExtent(pages, components);
-    MapComponentGloFASStationsTrigger(pages, components);
+    MapComponentLayersDefault(pages, components, disasterType);
+    MapComponentFloodExtent(pages, components, disasterType);
+    MapComponentGloFASStationsTrigger(pages, components, disasterType);
   });
 
   test.describe('AggregatesComponent', () => {
-    AggregateComponentEventCount(pages, components);
-    AggregateComponentHeaderColour(pages, components);
+    AggregateComponentEventCount(pages, components, disasterType);
+    AggregateComponentHeaderColour(pages, components, disasterType);
   });
 
   test.describe('ChatComponent', () => {
-    ChatComponentEventClick(pages, components);
-    ChatComponentEventCount(pages, components);
-    ChatComponentInfoPopover(pages, components);
+    ChatComponentEventClick(pages, components, disasterType);
+    ChatComponentEventCount(pages, components, disasterType);
+    ChatComponentInfoPopover(pages, components, disasterType);
   });
 });

--- a/tests/e2e/tests/TimelineComponent/TimelineComponentDisabled.ts
+++ b/tests/e2e/tests/TimelineComponent/TimelineComponentDisabled.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(14, 'Timeline should be disabled'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,

--- a/tests/e2e/tests/TimelineComponent/TimelineComponentVisible.ts
+++ b/tests/e2e/tests/TimelineComponent/TimelineComponentVisible.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(15, 'Timeline component elements should be visible'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,

--- a/tests/e2e/tests/UserStateComponent/UserStateComponentLogout.ts
+++ b/tests/e2e/tests/UserStateComponent/UserStateComponentLogout.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(4, 'Logout should load login page'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,

--- a/tests/e2e/tests/UserStateComponent/UserStateComponentVisible.ts
+++ b/tests/e2e/tests/UserStateComponent/UserStateComponentVisible.ts
@@ -4,7 +4,11 @@ import { NoTriggerDataSet } from 'testData/testData.enum';
 
 import { Components, Pages } from '../../helpers/interfaces';
 
-export default (pages: Partial<Pages>, components: Partial<Components>) => {
+export default (
+  pages: Partial<Pages>,
+  components: Partial<Components>,
+  disasterType: string,
+) => {
   test(
     qase(3, 'User state component elements should be visible'),
     {
@@ -22,7 +26,7 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       }
 
       // Navigate to disaster type the data was mocked for
-      await dashboard.navigateToFloodDisasterType();
+      await dashboard.navigateToDisasterType(disasterType);
       // Assertions
       await userState.headerComponentIsVisible({
         countryName: NoTriggerDataSet.CountryName,


### PR DESCRIPTION
## Describe your changes

Initial step at making the e2e test disaster-type agnostic, by replacing hard-coded references to 'floods' by a variable. Still the code currently only fully works if disasterType='floods', because some of the tests e.g. refer to Glofas stations specifically. As a next step in the [Lesotho setup item](https://dev.azure.com/redcrossnl/IBF/_sprints/taskboard/IBF%20Team/IBF/Sprint%204?workitem=31826) I want to do an attempt at changing this to LSO (or UGA) drought and seeing how far it gets.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

1. Any helpful instructions or clarifications...

