### PR TITLE
Un-skip e2e test

### DIFF
--- a/interfaces/IBF-dashboard/src/app/components/logos/logos.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/logos/logos.component.html
@@ -2,5 +2,5 @@
   logo of (country | async)?.countryLogos[(disasterType | async)?.disasterType];
   track logo
 ) {
-  <img data-test="logo-image" src="assets/logos/{{ logo }}" />
+  <img data-testid="logo-image" src="assets/logos/{{ logo }}" />
 }

--- a/interfaces/IBF-dashboard/src/app/components/user-state/user-state.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/user-state/user-state.component.html
@@ -30,19 +30,16 @@
     </div>
     <div class="ion-align-items-center">
       <ion-row class="ion-align-items-center">
-        <app-logos data-testid="user-state-country-logos"></app-logos>
+        <app-logos></app-logos>
         <ion-item lines="none">
-          <ion-col
-            data-testid="user-state-display-name-label"
-            class="ion-no-padding"
-          >
+          <ion-col class="ion-no-padding">
             @if (isLoggedIn) {
               <ion-title size="small" class="ion-no-padding"
                 >Logged In As:</ion-title
               >
               <ion-title
                 size="small"
-                data-test="user-display-name"
+                data-testid="user-display-name"
                 class="ion-no-padding"
               >
                 <strong

--- a/tests/e2e/Pages/UserStateComponent.ts
+++ b/tests/e2e/Pages/UserStateComponent.ts
@@ -14,12 +14,8 @@ class UserStateComponent extends DashboardPage {
     super(page);
     this.page = page;
     this.header = this.page.getByTestId('heading-display-name-span');
-    this.countryLogos = this.page
-      .getByTestId('user-state-country-logos')
-      .nth(0);
-    this.userLoggedInLabel = this.page
-      .getByTestId('user-state-display-name-label')
-      .nth(0);
+    this.countryLogos = this.page.getByTestId('logo-image');
+    this.userLoggedInLabel = this.page.getByTestId('user-display-name');
     this.logOutButton = this.page.getByTestId('user-state-logout-button');
   }
 
@@ -55,11 +51,14 @@ class UserStateComponent extends DashboardPage {
     firstName: string;
     lastName: string;
   }) {
+    const countryLogosCount = await this.countryLogos.count();
+    for (let i = 0; i < countryLogosCount; i++) {
+      await expect(this.countryLogos.nth(i)).toBeVisible();
+      console.log(i);
+    }
+
     await expect(this.dashboardHomeButton).toBeVisible();
-    await expect(this.countryLogos).toBeVisible(); // skip-reason: test fails often because it claims the element is hidden instead of visible
-    await expect(this.userLoggedInLabel).toHaveText(
-      `Logged In As:${firstName} ${lastName}`,
-    );
+    await expect(this.userLoggedInLabel).toHaveText(`${firstName} ${lastName}`);
     await expect(this.logOutButton).toBeVisible();
   }
 

--- a/tests/e2e/Pages/UserStateComponent.ts
+++ b/tests/e2e/Pages/UserStateComponent.ts
@@ -54,7 +54,6 @@ class UserStateComponent extends DashboardPage {
     const countryLogosCount = await this.countryLogos.count();
     for (let i = 0; i < countryLogosCount; i++) {
       await expect(this.countryLogos.nth(i)).toBeVisible();
-      console.log(i);
     }
 
     await expect(this.dashboardHomeButton).toBeVisible();

--- a/tests/e2e/tests/UserStateComponent/UserStateComponentVisible.ts
+++ b/tests/e2e/tests/UserStateComponent/UserStateComponentVisible.ts
@@ -10,7 +10,7 @@ export default (
   disasterType: string,
 ) => {
   // Skip for now, as test often fails
-  test.skip(
+  test(
     qase(3, 'User state component elements should be visible'),
     {
       annotation: {

--- a/tests/e2e/tests/UserStateComponent/UserStateComponentVisible.ts
+++ b/tests/e2e/tests/UserStateComponent/UserStateComponentVisible.ts
@@ -9,7 +9,6 @@ export default (
   components: Partial<Components>,
   disasterType: string,
 ) => {
-  // Skip for now, as test often fails
   test(
     qase(3, 'User state component elements should be visible'),
     {


### PR DESCRIPTION
## Describe your changes

Fix one e2e test that was failing after the Playwright framework refactor.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

I have switched the data-testids that were used for selecting the locators. It seems that they were not visible anymore after the refactor even tho there seems to be no connection between the refactor and testids. I have reused old ids by adding playwright readable format to them 'data-testid' instead of 'data-test'. Also I refactored the test itself to use those ids correctly. 

