### PR TITLE
Fix flaky map/ legend/ aggregates e2e test

### DIFF
--- a/tests/e2e/Pages/MapComponent.ts
+++ b/tests/e2e/Pages/MapComponent.ts
@@ -143,7 +143,12 @@ class MapComponent extends DashboardPage {
 
   async clickLayerCheckbox({ layerName }: { layerName: string }) {
     // Remove Glofas station from the map (in case the mock is for floods)
+    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForLoadState('domcontentloaded');
+
     await this.layerMenuToggle.click();
+    await this.page.waitForSelector('data-testid=matrix-layer-name');
+
     const getLayerRow = this.page
       .getByTestId('matrix-layer-name')
       .filter({ hasText: layerName });
@@ -273,6 +278,7 @@ class MapComponent extends DashboardPage {
     await this.page.waitForLoadState('networkidle');
     await this.page.waitForLoadState('domcontentloaded');
     await this.page.waitForSelector('.leaflet-interactive');
+    await this.page.waitForTimeout(200);
 
     // Assert that Aggregates title is visible and does not contain the text 'National View'
 


### PR DESCRIPTION
## Describe your changes

Fixes random failures of the test when locator couldn't be found and actions were executed in random order.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

Added:

1. Await for domContentLoaded
2. Await for networkIdle
3. 200ms await before hovering over the map

