### PR TITLE
test: refactors to make tests less flaky

### DIFF
--- a/interfaces/IBF-dashboard/src/app/components/aggregates/aggregates.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/aggregates/aggregates.component.html
@@ -3,7 +3,6 @@
     <ion-row
       class="component-title"
       style="background: var(--ion-color-ibf-secondary)"
-      data-testid="action-title"
     >
       <ion-col class="ion-no-padding" size-lg="11" size-md="11" size-xs="11">
         <ion-item
@@ -12,14 +11,20 @@
           color="ibf-secondary"
         >
           <ion-col class="ion-no-padding ion-no-margin ion-align-items-center">
-            <ion-label color="ibf-black" class="ion-text-wrap"
+            <ion-label
+              color="ibf-black"
+              class="ion-text-wrap"
+              data-testid="aggregates-header-label"
               ><ion-text
                 ><strong>{{
                   getAggregatesHeader(mapView | async).headerLabel
                 }}</strong></ion-text
               ></ion-label
             >
-            <ion-label color="ibf-black" class="ion-text-wrap"
+            <ion-label
+              color="ibf-black"
+              class="ion-text-wrap"
+              data-testid="aggregates-sub-header-label"
               ><ion-text
                 [innerHTML]="
                   getAggregatesHeader(mapView | async).subHeaderLabel
@@ -32,7 +37,7 @@
       <ion-col size-lg="1" size-md="1" size-xs="1">
         <ion-item
           class="aggregate-item-information-icon ion-no-padding m-0 cursor-pointer"
-          data-testid="aggregates-title-info-icon"
+          data-testid="aggregates-header-info-icon"
           color="transparent"
           lines="none"
         >

--- a/interfaces/IBF-dashboard/src/app/components/event-switcher/event-switcher.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/event-switcher/event-switcher.component.ts
@@ -6,7 +6,6 @@ import { EventService, EventSummary } from 'src/app/services/event.service';
 import { TimelineService } from 'src/app/services/timeline.service';
 import { DisasterTypeKey } from 'src/app/types/disaster-type-key';
 import { EventState } from 'src/app/types/event-state';
-import { LeadTime } from 'src/app/types/lead-time';
 import { TimelineState } from 'src/app/types/timeline-state';
 
 @Component({
@@ -96,7 +95,7 @@ export class EventSwitcherComponent implements OnInit, OnDestroy {
       this.eventService.switchEvent(event.eventName);
 
       this.timelineService.handleTimeStepButtonClick(
-        (event.firstTriggerLeadTime || event.firstLeadTime) as LeadTime,
+        event.firstTriggerLeadTime || event.firstLeadTime,
         event.eventName,
       );
     }

--- a/interfaces/IBF-dashboard/src/app/components/map/map.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/map/map.component.ts
@@ -661,7 +661,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
           );
           this.eventService.switchEvent(feature.properties.eventName);
           this.timelineService.handleTimeStepButtonClick(
-            (event?.firstTriggerLeadTime || event?.firstLeadTime) as LeadTime,
+            event?.firstTriggerLeadTime || event?.firstLeadTime,
             event?.eventName,
           );
         }

--- a/interfaces/IBF-dashboard/src/app/components/matrix/matrix.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/matrix/matrix.component.html
@@ -22,7 +22,7 @@
       <ion-list class="ion-no-padding">
         @for (layer of getLayersInOrder(); track layer.name) {
           <ion-row class="ion-justify-content-between ion-nowrap">
-            <ion-item data-testid="matrix-layer-name" lines="none">
+            <ion-item className="matrix-layer {{ layer.name }}" lines="none">
               @if (layer.isLoading) {
                 <ion-spinner class="mx-[0.15rem]"></ion-spinner>
               } @else {

--- a/interfaces/IBF-dashboard/src/app/services/map.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/map.service.ts
@@ -930,6 +930,7 @@ export class MapService {
           fillOpacity,
           weight,
           color,
+          className: `admin-boundary ${layer.name}`,
         };
       }
     };

--- a/interfaces/IBF-dashboard/src/app/services/point-marker.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/point-marker.service.ts
@@ -129,27 +129,24 @@ export class PointMarkerService {
         e.eventName === markerProperties.stationName, // NOTE: this assumes events to be defined per station, and eventName=stationCode or stationName
     );
     // This reflects to take the trigger leadTime and not the earlier warning leadTime, in case of warning-to-trigger scenario
-    const eventLeadTime = (event?.firstTriggerLeadTime ||
-      event?.firstLeadTime) as LeadTime;
+    const eventLeadTime = event?.firstTriggerLeadTime || event?.firstLeadTime;
 
     const markerTitle = markerProperties.stationName;
+    const eapAlertClass = markerProperties.dynamicData?.eapAlertClass || 'no';
+    const markerClassName = `glofas-station glofas-station-${eapAlertClass}`;
     const markerIcon: IconOptions = {
       ...LEAFLET_MARKER_ICON_OPTIONS_BASE,
-      iconUrl: `assets/markers/glofas-station-${
-        markerProperties.dynamicData?.eapAlertClass || 'no'
-      }-trigger.svg`,
-      iconRetinaUrl: `assets/markers/glofas-station-${
-        markerProperties.dynamicData?.eapAlertClass || 'no'
-      }-trigger.svg`,
+      iconUrl: `assets/markers/glofas-station-${eapAlertClass}-trigger.svg`,
+      iconRetinaUrl: `assets/markers/glofas-station-${eapAlertClass}-trigger.svg`,
+      className: markerClassName,
     };
-    const className = `trigger-popup-${
-      markerProperties.dynamicData?.eapAlertClass || 'no'
-    }`;
+    const popupClassName = `trigger-popup-${eapAlertClass}`;
 
     const markerInstance = marker(markerLatLng, {
       title: markerTitle,
-      icon: markerIcon ? icon(markerIcon) : divIcon(),
-      alt: 'Glofas stations',
+      icon: markerIcon
+        ? icon(markerIcon)
+        : divIcon({ className: markerClassName }),
       zIndexOffset: 700,
     });
     markerInstance.bindPopup(
@@ -160,7 +157,7 @@ export class PointMarkerService {
       ),
       {
         minWidth: 350,
-        className,
+        className: popupClassName,
       },
     );
     markerInstance.on(

--- a/interfaces/IBF-dashboard/src/app/services/timeline.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/timeline.service.ts
@@ -187,8 +187,8 @@ export class TimelineService {
       ) {
         this.handleTimeStepButtonClick(
           this.eventState.event
-            ? ((this.eventState.event.firstTriggerLeadTime ||
-                this.eventState.event.firstLeadTime) as LeadTime)
+            ? this.eventState.event.firstTriggerLeadTime ||
+                this.eventState.event.firstLeadTime
             : this.eventState.events?.length > 0
               ? null
               : this.getFallbackNoTriggerLeadTime(

--- a/tests/e2e/Pages/ActionSummaryComponent.ts
+++ b/tests/e2e/Pages/ActionSummaryComponent.ts
@@ -13,10 +13,6 @@ class ActionsSummaryComponent extends DashboardPage {
     this.tooltipButton = this.page.getByTestId('action-summary-info');
   }
 
-  async actionsSummaryIsVisible() {
-    console.log('aggregateComponentIsVisible');
-  }
-
   async validateActionsSummaryInfoButtons() {
     const counttoolTipInfoButton = await this.tooltipButton.count();
 
@@ -28,7 +24,6 @@ class ActionsSummaryComponent extends DashboardPage {
       );
 
       await toolTipInfoButton.click();
-      await this.page.waitForTimeout(200);
       await this.validateLabel({ text: AREAS_OF_FOCUS[i].label });
       await this.validateDescription({ text: descriptionText });
       await this.page.getByTestId('close-matrix-icon').click();

--- a/tests/e2e/Pages/AggregatesComponent.ts
+++ b/tests/e2e/Pages/AggregatesComponent.ts
@@ -105,14 +105,14 @@ class AggregatesComponent extends DashboardPage {
       EnglishTranslations.ApproximateNumberDisclaimer,
     );
 
-    // wait for opover layer to be laoded and click to remove it
-    await this.page.waitForTimeout(500);
+    // wait for popover layer to be laoded and click to remove it
     await this.popoverLayer.click();
 
     // click on the total exposed population info icon and validate the popover content
     const exposedPopulationLayer = this.aggregatesLayerRow.filter({
       hasText: 'Exposed population',
     });
+    await this.page.locator('ion-backdrop').last().click();
     await exposedPopulationLayer.getByTestId('aggregates-info-icon').click();
     const layerInfoTitle = await this.layerInfoPopoverTitle.textContent();
     const layerInfoContent = await this.layerInfoPopoverContent.textContent();

--- a/tests/e2e/Pages/AggregatesComponent.ts
+++ b/tests/e2e/Pages/AggregatesComponent.ts
@@ -16,11 +16,12 @@ const expectedLayersNames = [
 class AggregatesComponent extends DashboardPage {
   readonly page: Page;
   readonly aggregateSectionColumn: Locator;
-  readonly aggregatesTitleHeader: Locator;
+  readonly aggregatesHeaderLabel: Locator;
+  readonly aggregatesSubHeaderLabel: Locator;
+  readonly aggreagtesHeaderInfoIcon: Locator;
   readonly aggregatesInfoIcon: Locator;
   readonly aggregatesLayerRow: Locator;
   readonly aggregatesAffectedNumber: Locator;
-  readonly aggreagtesTitleInfoIcon: Locator;
   readonly approximateDisclaimer: Locator;
   readonly popoverLayer: Locator;
   readonly layerInfoPopoverTitle: Locator;
@@ -33,14 +34,19 @@ class AggregatesComponent extends DashboardPage {
     this.aggregateSectionColumn = this.page.getByTestId(
       'dashboard-aggregate-section',
     );
-    this.aggregatesTitleHeader = this.page.getByTestId('action-title');
+    this.aggregatesHeaderLabel = this.page.getByTestId(
+      'aggregates-header-label',
+    );
+    this.aggregatesSubHeaderLabel = this.page.getByTestId(
+      'aggregates-sub-header-label',
+    );
+    this.aggreagtesHeaderInfoIcon = this.page.getByTestId(
+      'aggregates-header-info-icon',
+    );
     this.aggregatesInfoIcon = this.page.getByTestId('aggregates-info-icon');
     this.aggregatesLayerRow = this.page.getByTestId('aggregates-row');
     this.aggregatesAffectedNumber = this.page.getByTestId(
       'aggregates-affected-number',
-    );
-    this.aggreagtesTitleInfoIcon = this.page.getByTestId(
-      'aggregates-title-info-icon',
     );
     this.approximateDisclaimer = this.page.getByTestId(
       'disclaimer-approximate-message',
@@ -67,14 +73,15 @@ class AggregatesComponent extends DashboardPage {
     const affectedNumbers = await this.page.$$(
       '[data-testid="aggregates-affected-number"]',
     );
-    const headerText = await this.aggregatesTitleHeader.textContent();
-    const headerTextModified = headerText?.replace(/View0/, 'View 0');
+    const headerText = await this.aggregatesHeaderLabel.textContent();
+    const subHeaderText = await this.aggregatesSubHeaderLabel.textContent();
     const layerCount = await this.aggregatesLayerRow.count();
     const iconLayerCount = await this.aggregatesInfoIcon.count();
 
     // Basic Assertions
-    expect(headerTextModified).toBe('National View 0 Predicted Flood(s)');
-    await expect(this.aggreagtesTitleInfoIcon).toBeVisible();
+    expect(headerText).toBe('National View');
+    expect(subHeaderText).toBe('0 Predicted Flood(s)');
+    await expect(this.aggreagtesHeaderInfoIcon).toBeVisible();
     expect(layerCount).toBe(5);
     expect(iconLayerCount).toBe(5);
 
@@ -92,7 +99,7 @@ class AggregatesComponent extends DashboardPage {
 
   async validatesAggregatesInfoButtons() {
     // click on the first info icon and validate the popover content
-    await this.aggreagtesTitleInfoIcon.click();
+    await this.aggreagtesHeaderInfoIcon.click();
     const disclaimerText = await this.approximateDisclaimer.textContent();
     expect(disclaimerText).toContain(
       EnglishTranslations.ApproximateNumberDisclaimer,
@@ -130,11 +137,12 @@ class AggregatesComponent extends DashboardPage {
     await this.page.goBack();
   }
 
-  async getNumberOfPredictedEvents() {
-    const actionHeaderText = await this.aggregatesTitleHeader.textContent();
-    const eventsNumber = actionHeaderText?.match(/\d+/g);
+  async getEventCount() {
+    const aggregatesHeaderLabel =
+      await this.aggregatesSubHeaderLabel.textContent();
+    const eventCount = aggregatesHeaderLabel?.match(/\d+/g);
 
-    return eventsNumber ? parseInt(eventsNumber[0], 10) : null;
+    return eventCount ? parseInt(eventCount[0], 10) : null;
   }
 
   async validateColorOfAggregatesHeaderByClass({

--- a/tests/e2e/Pages/DashboardPage.ts
+++ b/tests/e2e/Pages/DashboardPage.ts
@@ -84,7 +84,6 @@ class DashboardPage {
 
   async waitForPageToBeLoadedAndStable() {
     await this.page.waitForLoadState('domcontentloaded');
-    await this.page.waitForTimeout(500);
   }
 }
 

--- a/tests/e2e/Pages/MapComponent.ts
+++ b/tests/e2e/Pages/MapComponent.ts
@@ -129,7 +129,6 @@ class MapComponent extends DashboardPage {
 
   async areAdminBoundariesVisible({ layerName }: { layerName?: string } = {}) {
     await this.waitForMapToBeLoaded();
-    await this.adminBoundaries.first().waitFor();
 
     const layer = layerName
       ? this.page.locator(`.admin-boundary.${layerName}`)
@@ -148,7 +147,6 @@ class MapComponent extends DashboardPage {
     await this.waitForMapToBeLoaded();
 
     await this.layerMenuToggle.click();
-    await this.layerMenu.waitFor();
 
     const checkbox = this.page
       .locator(`.matrix-layer.${layerName}`)
@@ -161,6 +159,8 @@ class MapComponent extends DashboardPage {
     const checkbox = this.page
       .locator(`.matrix-layer.${layerName}`)
       .getByTestId('matrix-checkbox');
+
+    await this.page.waitForTimeout(100);
 
     // In case of checbox being checked the name attribute should be "checkbox"
     const nameAttribute = await checkbox.getAttribute('name');
@@ -199,7 +199,6 @@ class MapComponent extends DashboardPage {
 
     for (let i = 0; i < layerCount; i++) {
       try {
-        await this.page.waitForTimeout(50);
         const layerRow = this.matrixLayers.nth(i);
         if (await layerRow.isVisible()) {
           const nameAttribute = await layerRow.textContent();
@@ -232,11 +231,11 @@ class MapComponent extends DashboardPage {
 
     // Wait for the page to load
     await this.waitForMapToBeLoaded();
-    await this.adminBoundaries.first().waitFor();
-    await this.page.waitForTimeout(200);
+
+    const adminBoundaries = this.page.locator('.admin-boundary');
 
     // Assert that Aggregates title is visible and does not contain the text 'National View'
-    await this.adminBoundaries.first().hover();
+    await adminBoundaries.first().hover();
     await expect(aggregates.aggregatesHeaderLabel).not.toContainText(
       'National View',
     );
@@ -299,9 +298,6 @@ class MapComponent extends DashboardPage {
     eapAlertClass?: string;
     isVisible?: boolean;
   } = {}) {
-    // Wait for the page to load
-    await this.glofasStations.first().waitFor();
-
     const markers = this.page.locator(`.glofas-station-${eapAlertClass}`);
 
     const count = await markers.count();

--- a/tests/e2e/Pages/MapComponent.ts
+++ b/tests/e2e/Pages/MapComponent.ts
@@ -248,9 +248,8 @@ class MapComponent extends DashboardPage {
     await this.page.waitForTimeout(200);
 
     // Assert that Aggregates title is visible and does not contain the text 'National View'
-
     await this.adminBoundaries.first().hover();
-    await expect(aggregates.aggregatesTitleHeader).not.toContainText(
+    await expect(aggregates.aggregatesHeaderLabel).not.toContainText(
       'National View',
     );
   }

--- a/tests/e2e/Pages/MapComponent.ts
+++ b/tests/e2e/Pages/MapComponent.ts
@@ -299,21 +299,9 @@ class MapComponent extends DashboardPage {
     await expect(this.redCrossMarker.nth(nthSelector)).toBeVisible();
   }
 
-  async validateLayersAreVisibleByName({
-    layerNames = [],
-  }: {
-    layerNames: string[];
-  }) {
-    for (const layerName of layerNames) {
-      await this.page.waitForSelector(`[alt="${layerName}"]`);
-      const layer = this.page.getByAltText(layerName);
-      // Count the number of markers
-      const markersCount = await layer.count();
-      const nthSelector = this.getRandomInt(1, markersCount) - 1;
-
-      // Assert that the number of gloFAS markers is greater than 0 and randomly select one to be visible
-      expect(markersCount).toBeGreaterThan(0);
-      await expect(layer.nth(nthSelector)).toBeVisible();
+  async isLayerVisible({ layerName }: { layerName: string }) {
+    if (layerName === 'glofas_stations') {
+      await this.glofasMarkersAreVisible();
     }
   }
 

--- a/tests/e2e/Pages/MapComponent.ts
+++ b/tests/e2e/Pages/MapComponent.ts
@@ -14,9 +14,8 @@ class MapComponent extends DashboardPage {
   readonly breadCrumbAdminArea3View: Locator;
   readonly legend: Locator;
   readonly layerMenu: Locator;
+  readonly matrixLayers: Locator;
   readonly adminBoundaries: Locator;
-  readonly layerCheckbox: Locator;
-  readonly layerRadioButton: Locator;
   readonly legendHeader: Locator;
   readonly layerMenuToggle: Locator;
   readonly redCrossMarker: Locator;
@@ -45,11 +44,10 @@ class MapComponent extends DashboardPage {
     );
     this.legend = this.page.getByTestId('map-legend');
     this.layerMenu = this.page.getByTestId('layer-menu');
+    this.matrixLayers = this.page.locator('matrix-layer');
     this.adminBoundaries = this.page.locator(
       '.leaflet-ibf-admin-boundaries-pane .leaflet-interactive',
     );
-    this.layerCheckbox = this.page.getByTestId('matrix-checkbox');
-    this.layerRadioButton = this.page.getByTestId('matrix-radio-button');
     this.legendHeader = this.page.getByTestId('map-legend-header');
     this.layerMenuToggle = this.page.getByTestId('layer-menu-toggle-button');
     this.redCrossMarker = this.page.getByAltText('Red Cross branches');
@@ -148,28 +146,27 @@ class MapComponent extends DashboardPage {
     }
   }
 
-  async clickLayerCheckbox({ layerName }: { layerName: string }) {
+  async checkLayerCheckbox({ layerName }: { layerName: string }) {
     // Remove Glofas station from the map (in case the mock is for floods)
     await this.waitForMapToBeLoaded();
 
     await this.layerMenuToggle.click();
-    await this.page.waitForSelector('data-testid=matrix-layer-name');
+    await this.layerMenu.waitFor();
 
-    const getLayerRow = this.page
-      .getByTestId('matrix-layer-name')
-      .filter({ hasText: layerName });
-    const layerCheckbox = getLayerRow.locator(this.layerCheckbox);
-    await layerCheckbox.click();
+    const checkbox = this.page
+      .locator(`.matrix-layer.${layerName}`)
+      .getByTestId('matrix-checkbox');
+
+    await checkbox.click();
   }
 
-  async verifyLayerCheckboxCheckedByName({ layerName }: { layerName: string }) {
-    const getLayerRow = this.page
-      .getByTestId('matrix-layer-name')
-      .filter({ hasText: layerName });
-    const layerCheckbox = getLayerRow.locator(this.layerCheckbox);
+  async isLayerCheckboxChecked({ layerName }: { layerName: string }) {
+    const checkbox = this.page
+      .locator(`.matrix-layer.${layerName}`)
+      .getByTestId('matrix-checkbox');
 
     // In case of checbox being checked the name attribute should be "checkbox"
-    const nameAttribute = await layerCheckbox.getAttribute('name');
+    const nameAttribute = await checkbox.getAttribute('name');
     const isChecked = nameAttribute === 'checkbox';
 
     if (!isChecked) {
@@ -177,18 +174,13 @@ class MapComponent extends DashboardPage {
     }
   }
 
-  async verifyLayerRadioButtonCheckedByName({
-    layerName,
-  }: {
-    layerName: string;
-  }) {
-    const getLayerRow = this.page
-      .getByTestId('matrix-layer-name')
-      .filter({ hasText: layerName });
-    const layerCheckbox = getLayerRow.locator(this.layerRadioButton);
+  async isLayerRadioButtonChecked({ layerName }: { layerName: string }) {
+    const radioButton = this.page
+      .locator(`.matrix-layer.${layerName}`)
+      .getByTestId('matrix-radio-button');
 
-    // In case of checbox being checked the name attribute should be "checkbox"
-    const nameAttribute = await layerCheckbox.getAttribute('name');
+    // In case of radio button being checked the name attribute should be "radio-button-on-outline"
+    const nameAttribute = await radioButton.getAttribute('name');
     const isChecked = nameAttribute === 'radio-button-on-outline';
 
     if (!isChecked) {
@@ -206,13 +198,12 @@ class MapComponent extends DashboardPage {
   }
 
   async validateInfoIconInteractions() {
-    const getLayerRow = this.page.getByTestId('matrix-layer-name');
-    const layerCount = await getLayerRow.count();
+    const layerCount = await this.matrixLayers.count();
 
     for (let i = 0; i < layerCount; i++) {
       try {
-        await this.page.waitForTimeout(200);
-        const layerRow = getLayerRow.nth(i);
+        await this.page.waitForTimeout(50);
+        const layerRow = this.matrixLayers.nth(i);
         if (await layerRow.isVisible()) {
           const nameAttribute = await layerRow.textContent();
           if (nameAttribute) {

--- a/tests/e2e/Pages/MapComponent.ts
+++ b/tests/e2e/Pages/MapComponent.ts
@@ -20,7 +20,7 @@ class MapComponent extends DashboardPage {
   readonly legendHeader: Locator;
   readonly layerMenuToggle: Locator;
   readonly redCrossMarker: Locator;
-  readonly gloFASMarker: Locator;
+  readonly glofasStations: Locator;
   readonly triggerAreaOutlines: Locator;
   readonly closeButtonIcon: Locator;
   readonly layerInfoContent: Locator;
@@ -53,7 +53,7 @@ class MapComponent extends DashboardPage {
     this.legendHeader = this.page.getByTestId('map-legend-header');
     this.layerMenuToggle = this.page.getByTestId('layer-menu-toggle-button');
     this.redCrossMarker = this.page.getByAltText('Red Cross branches');
-    this.gloFASMarker = this.page.getByAltText('Glofas stations');
+    this.glofasStations = this.page.locator('.glofas-station');
     this.triggerAreaOutlines = this.page.locator(
       '[stroke="var(--ion-color-ibf-outline-red)"]',
     );
@@ -299,19 +299,6 @@ class MapComponent extends DashboardPage {
     await expect(this.redCrossMarker.nth(nthSelector)).toBeVisible();
   }
 
-  async gloFASMarkersAreVisible() {
-    // Wait for the page to load
-    await this.page.waitForSelector('[alt="Glofas stations"]');
-
-    // Count the number of gloFAS markers
-    const gloFASMarkersCount = await this.gloFASMarker.count();
-    const nthSelector = this.getRandomInt(1, gloFASMarkersCount) - 1;
-
-    // Assert that the number of gloFAS markers is greater than 0 and randomly select one to be visible
-    expect(gloFASMarkersCount).toBeGreaterThan(0);
-    await expect(this.gloFASMarker.nth(nthSelector)).toBeVisible();
-  }
-
   async validateLayersAreVisibleByName({
     layerNames = [],
   }: {
@@ -330,28 +317,27 @@ class MapComponent extends DashboardPage {
     }
   }
 
-  async gloFASMarkersAreVisibleByWarning({
-    glosfasStationStatus,
-    isVisible,
+  async glofasMarkersAreVisible({
+    eapAlertClass = 'no',
+    isVisible = true,
   }: {
-    glosfasStationStatus: string;
-    isVisible: boolean;
-  }) {
-    // Select from: ""glofas-station-max-trigger", "glofas-station-med-trigger", "glofas-station-min-trigger"
-    // We don't have specyfic selectors for each of the markers, so we need have to use src as a selector which is not ideal
-    const glofasMarker = this.page.locator(
-      `img[src="assets/markers/${glosfasStationStatus}.svg"][alt="Glofas stations"]`,
-    );
+    eapAlertClass?: string;
+    isVisible?: boolean;
+  } = {}) {
+    // Wait for the page to load
+    await this.glofasStations.first().waitFor();
 
-    const markersCount = await glofasMarker.count();
+    const markers = this.page.locator(`.glofas-station-${eapAlertClass}`);
+
+    const count = await markers.count();
     if (isVisible) {
-      const nthSelector = this.getRandomInt(1, markersCount) - 1;
+      const nthSelector = this.getRandomInt(1, count) - 1; // pick a random marker
 
-      expect(markersCount).toBeGreaterThan(0);
-      await expect(glofasMarker.nth(nthSelector)).toBeVisible();
+      expect(count).toBeGreaterThan(0);
+      await expect(markers.nth(nthSelector)).toBeVisible();
     } else {
       // Assert that no markers are visible
-      expect(markersCount).toBe(0);
+      expect(count).toBe(0);
     }
   }
 

--- a/tests/e2e/Pages/MapComponent.ts
+++ b/tests/e2e/Pages/MapComponent.ts
@@ -23,7 +23,6 @@ class MapComponent extends DashboardPage {
   readonly triggerAreaOutlines: Locator;
   readonly closeButtonIcon: Locator;
   readonly layerInfoContent: Locator;
-  readonly aggregates: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -45,9 +44,7 @@ class MapComponent extends DashboardPage {
     this.legend = this.page.getByTestId('map-legend');
     this.layerMenu = this.page.getByTestId('layer-menu');
     this.matrixLayers = this.page.locator('matrix-layer');
-    this.adminBoundaries = this.page.locator(
-      '.leaflet-ibf-admin-boundaries-pane .leaflet-interactive',
-    );
+    this.adminBoundaries = this.page.locator('.admin-boundary');
     this.legendHeader = this.page.getByTestId('map-legend-header');
     this.layerMenuToggle = this.page.getByTestId('layer-menu-toggle-button');
     this.redCrossMarker = this.page.getByAltText('Red Cross branches');
@@ -57,9 +54,6 @@ class MapComponent extends DashboardPage {
     );
     this.closeButtonIcon = this.page.getByTestId('close-matrix-icon');
     this.layerInfoContent = this.page.getByTestId('layer-info-content');
-    this.aggregates = this.page.locator(
-      '.leaflet-ibf-aggregate-pane .leaflet-interactive',
-    );
   }
 
   async waitForMapToBeLoaded() {
@@ -133,16 +127,19 @@ class MapComponent extends DashboardPage {
     }
   }
 
-  async assertAdminBoundariesVisible() {
+  async areAdminBoundariesVisible({ layerName }: { layerName?: string } = {}) {
     await this.waitForMapToBeLoaded();
-    await this.page.waitForTimeout(2000); // This is a workaround for the issue with the map not loading in the same moment as the dom
     await this.adminBoundaries.first().waitFor();
 
-    const count = await this.adminBoundaries.count();
+    const layer = layerName
+      ? this.page.locator(`.admin-boundary.${layerName}`)
+      : this.adminBoundaries;
+
+    const count = await layer.count();
 
     expect(count).toBeGreaterThan(0);
     for (let i = 0; i < count; i++) {
-      await expect(this.adminBoundaries.nth(i)).toBeVisible();
+      await expect(layer.nth(i)).toBeVisible();
     }
   }
 
@@ -317,14 +314,6 @@ class MapComponent extends DashboardPage {
       // Assert that no markers are visible
       expect(count).toBe(0);
     }
-  }
-
-  // This method checks that when radio button is checked then the layer is visible in leaflet-ibf-aggregate-pane
-  // Only one radio button can be checked at a time
-  // It valdates the functionality not data displayed
-  async validateAggregatesAreVisible() {
-    const count = await this.aggregates.count();
-    expect(count).toBeGreaterThan(0);
   }
 
   async validateLayerIsVisibleInMapBySrcElement({

--- a/tests/e2e/testData/testData.enum.ts
+++ b/tests/e2e/testData/testData.enum.ts
@@ -26,7 +26,7 @@ export const DISASTER_TYPES_WITH_INACTIVE_TIMELINE = ['floods', 'flash-floods'];
 // NOTE: this is a first starting point of starting to work more with statically defined test data. Move this to separate const file.
 export const ACTIVE_LAYERS: Record<string, string[]> = {
   floods: [
-    'Glofas stations',
+    'glofas_stations',
     // 'Community notifications', // This active layer does not come with any default (mock) data, so therefore ignore here
   ],
   drought: [

--- a/tests/e2e/tests/AggregatesComponent/AggregateComponentButtonClick.ts
+++ b/tests/e2e/tests/AggregatesComponent/AggregateComponentButtonClick.ts
@@ -21,9 +21,5 @@ export default (
     await aggregates.aggregateComponentIsVisible();
     await aggregates.validatesAggregatesInfoButtons();
     await aggregates.validateLayerPopoverExternalLink();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/AggregatesComponent/AggregateComponentEventCount.ts
+++ b/tests/e2e/tests/AggregatesComponent/AggregateComponentEventCount.ts
@@ -28,9 +28,5 @@ export default (
 
     // check if the number of warning events is equal to the number of aggregated events
     expect(eventCount).toBeGreaterThan(0);
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/AggregatesComponent/AggregateComponentEventCount.ts
+++ b/tests/e2e/tests/AggregatesComponent/AggregateComponentEventCount.ts
@@ -24,10 +24,10 @@ export default (
     });
 
     // get the number of warning events and aggregated events
-    const aggregatesEventCount = await aggregates.getNumberOfPredictedEvents();
+    const eventCount = await aggregates.getEventCount();
 
     // check if the number of warning events is equal to the number of aggregated events
-    expect(aggregatesEventCount).toBeGreaterThan(0);
+    expect(eventCount).toBeGreaterThan(0);
 
     // Reload the page to prepare for next test
     await dashboard.page.goto('/');

--- a/tests/e2e/tests/AggregatesComponent/AggregateComponentHeaderColour.ts
+++ b/tests/e2e/tests/AggregatesComponent/AggregateComponentHeaderColour.ts
@@ -27,9 +27,5 @@ export default (
     await aggregates.validateColorOfAggregatesHeaderByClass({
       isTrigger: true,
     });
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/AggregatesComponent/AggregateComponentTitleHover.ts
+++ b/tests/e2e/tests/AggregatesComponent/AggregateComponentTitleHover.ts
@@ -19,7 +19,6 @@ export default (
     await dashboard.navigateToDisasterType(disasterType);
     // Assertions
     await aggregates.aggregateComponentIsVisible();
-    await map.clickLayerCheckbox({ layerName: 'Glofas stations' });
     await map.assertAggregateTitleOnHoverOverMap();
 
     // Reload the page to prepare for next test

--- a/tests/e2e/tests/AggregatesComponent/AggregateComponentTitleHover.ts
+++ b/tests/e2e/tests/AggregatesComponent/AggregateComponentTitleHover.ts
@@ -20,9 +20,5 @@ export default (
     // Assertions
     await aggregates.aggregateComponentIsVisible();
     await map.assertAggregateTitleOnHoverOverMap();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/AggregatesComponent/AggregatesComponentVisible.ts
+++ b/tests/e2e/tests/AggregatesComponent/AggregatesComponentVisible.ts
@@ -20,9 +20,5 @@ export default (
     // Assertions
     await aggregates.aggregateComponentIsVisible();
     await aggregates.aggregatesAlementsDisplayedInNoTrigger();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/ChatComponent/ChatComponentButtonClick.ts
+++ b/tests/e2e/tests/ChatComponent/ChatComponentButtonClick.ts
@@ -29,9 +29,5 @@ export default (
     await chat.clickAndAssertTriggerLogButton({
       url: `/log?countryCodeISO3=${NoTriggerDataSet.CountryCode}&disasterType=${disasterType}`,
     });
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/ChatComponent/ChatComponentEventClick.ts
+++ b/tests/e2e/tests/ChatComponent/ChatComponentEventClick.ts
@@ -30,9 +30,5 @@ export default (
     });
     await chat.allDefaultButtonsArePresent();
     await chat.predictionButtonsAreActive();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/ChatComponent/ChatComponentEventCount.ts
+++ b/tests/e2e/tests/ChatComponent/ChatComponentEventCount.ts
@@ -36,9 +36,5 @@ export default (
 
     // check if the number of warning events is equal to the number of aggregated events
     expect(chatEventCount).toEqual(aggregatesEventCount);
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/ChatComponent/ChatComponentEventCount.ts
+++ b/tests/e2e/tests/ChatComponent/ChatComponentEventCount.ts
@@ -32,7 +32,7 @@ export default (
 
     // get the number of warning events and aggregated events
     const chatEventCount = await chat.predictionButtonsAreActive();
-    const aggregatesEventCount = await aggregates.getNumberOfPredictedEvents();
+    const aggregatesEventCount = await aggregates.getEventCount();
 
     // check if the number of warning events is equal to the number of aggregated events
     expect(chatEventCount).toEqual(aggregatesEventCount);

--- a/tests/e2e/tests/ChatComponent/ChatComponentInfoPopover.ts
+++ b/tests/e2e/tests/ChatComponent/ChatComponentInfoPopover.ts
@@ -29,9 +29,5 @@ export default (
       date,
     });
     await chat.validateEventsInfoButtonsAreClickable();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/ChatComponent/ChatComponentVisible.ts
+++ b/tests/e2e/tests/ChatComponent/ChatComponentVisible.ts
@@ -28,9 +28,5 @@ export default (
       date,
     });
     await chat.allDefaultButtonsArePresent();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/DashboardPage/DashboardPageVisible.ts
+++ b/tests/e2e/tests/DashboardPage/DashboardPageVisible.ts
@@ -43,9 +43,5 @@ export default (
     });
     await aggregates.aggregateComponentIsVisible();
     await map.mapComponentIsVisible();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/DisasterTypeComponent/DisasterTypeComponentSelect.ts
+++ b/tests/e2e/tests/DisasterTypeComponent/DisasterTypeComponentSelect.ts
@@ -27,9 +27,5 @@ export default (pages: Partial<Pages>, components: Partial<Components>) => {
       countryName: NoTriggerDataSet.CountryName,
       disasterName: 'drought',
     });
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/DisasterTypeComponent/DisasterTypeComponentVisible.ts
+++ b/tests/e2e/tests/DisasterTypeComponent/DisasterTypeComponentVisible.ts
@@ -24,9 +24,5 @@ export default (
     });
     await disasterTypeComponent.topBarComponentIsVisible();
     await disasterTypeComponent.allDisasterTypeElementsArePresent();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/MapComponent/MapComponentFloodExtent.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentFloodExtent.ts
@@ -30,9 +30,5 @@ export default (
     await map.assertLegendElementIsVisible({
       legendComponentName: 'Flood extent',
     });
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/MapComponent/MapComponentGloFASStations.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentGloFASStations.ts
@@ -29,8 +29,8 @@ export default (
     await map.isLegendOpen({ legendOpen: true });
     await map.isLayerMenuOpen({ layerMenuOpen: false });
     await map.clickLayerMenu();
-    await map.verifyLayerCheckboxCheckedByName({
-      layerName: 'Glofas stations',
+    await map.isLayerCheckboxChecked({
+      layerName: 'glofas_stations',
     });
     await map.assertLegendElementIsVisible({
       legendComponentName: 'GloFAS No action',

--- a/tests/e2e/tests/MapComponent/MapComponentGloFASStations.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentGloFASStations.ts
@@ -37,7 +37,7 @@ export default (
     });
 
     // GloFAS layer should be visible by default
-    await map.gloFASMarkersAreVisible();
+    await map.glofasMarkersAreVisible();
 
     // Reload the page to prepare for next test
     await dashboard.page.goto('/');

--- a/tests/e2e/tests/MapComponent/MapComponentGloFASStations.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentGloFASStations.ts
@@ -38,9 +38,5 @@ export default (
 
     // GloFAS layer should be visible by default
     await map.glofasMarkersAreVisible();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/MapComponent/MapComponentGloFASStationsTrigger.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentGloFASStationsTrigger.ts
@@ -29,8 +29,8 @@ export default (
     await map.isLegendOpen({ legendOpen: true });
     await map.isLayerMenuOpen({ layerMenuOpen: false });
     await map.clickLayerMenu();
-    await map.verifyLayerCheckboxCheckedByName({
-      layerName: 'Glofas stations',
+    await map.isLayerCheckboxChecked({
+      layerName: 'glofas_stations',
     });
     await map.assertLegendElementIsVisible({
       legendComponentName: 'GloFAS No action',

--- a/tests/e2e/tests/MapComponent/MapComponentGloFASStationsTrigger.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentGloFASStationsTrigger.ts
@@ -36,13 +36,9 @@ export default (
       legendComponentName: 'GloFAS No action',
     });
 
-    // GloFAS layer should be visible by default
-    await map.gloFASMarkersAreVisible();
-
     // Assert that the max warning GloFAS markers are not visible
-    await map.gloFASMarkersAreVisibleByWarning({
-      glosfasStationStatus: 'glofas-station-max-trigger',
-      isVisible: true,
+    await map.glofasMarkersAreVisible({
+      eapAlertClass: 'max',
     });
 
     // Reload the page to prepare for next test

--- a/tests/e2e/tests/MapComponent/MapComponentGloFASStationsTrigger.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentGloFASStationsTrigger.ts
@@ -40,9 +40,5 @@ export default (
     await map.glofasMarkersAreVisible({
       eapAlertClass: 'max',
     });
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/MapComponent/MapComponentGloFASStationsWarning.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentGloFASStationsWarning.ts
@@ -29,8 +29,8 @@ export default (
     await map.isLegendOpen({ legendOpen: true });
     await map.isLayerMenuOpen({ layerMenuOpen: false });
     await map.clickLayerMenu();
-    await map.verifyLayerCheckboxCheckedByName({
-      layerName: 'Glofas stations',
+    await map.isLayerCheckboxChecked({
+      layerName: 'glofas_stations',
     });
     await map.assertLegendElementIsVisible({
       legendComponentName: 'GloFAS No action',

--- a/tests/e2e/tests/MapComponent/MapComponentGloFASStationsWarning.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentGloFASStationsWarning.ts
@@ -44,9 +44,5 @@ export default (
       eapAlertClass: 'max',
       isVisible: false,
     });
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/MapComponent/MapComponentGloFASStationsWarning.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentGloFASStationsWarning.ts
@@ -37,11 +37,11 @@ export default (
     });
 
     // GloFAS layer should be visible by default
-    await map.gloFASMarkersAreVisible();
+    await map.glofasMarkersAreVisible();
 
     // Assert that the max warning GloFAS markers are not visible
-    await map.gloFASMarkersAreVisibleByWarning({
-      glosfasStationStatus: 'glofas-station-max-trigger',
+    await map.glofasMarkersAreVisible({
+      eapAlertClass: 'max',
       isVisible: false,
     });
 

--- a/tests/e2e/tests/MapComponent/MapComponentInfoPopover.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentInfoPopover.ts
@@ -33,9 +33,5 @@ export default (
 
     // Assert layer info icons to be intercative and contain basic required info
     await map.validateInfoIconInteractions();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/MapComponent/MapComponentInteractive.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentInteractive.ts
@@ -41,7 +41,7 @@ export default (
 
     // Select and deselect the layer
     await map.clickLayerMenu();
-    await map.clickLayerCheckbox({ layerName: 'Red Cross branches' });
+    await map.checkLayerCheckbox({ layerName: 'red_cross_branches' });
     await map.isLayerMenuOpen({ layerMenuOpen: true });
 
     // Red Cross branches layer should be visible

--- a/tests/e2e/tests/MapComponent/MapComponentInteractive.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentInteractive.ts
@@ -46,9 +46,5 @@ export default (
 
     // Red Cross branches layer should be visible
     await map.redCrossMarkersAreVisible();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/MapComponent/MapComponentLayersDefault.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentLayersDefault.ts
@@ -44,7 +44,7 @@ export default (
       legendComponentName: 'Exposed population',
     });
     // Validate that the layer checked with radio button is visible on the map in this case 'Exposed population' only one such layer can be checked at a time
-    await map.validateAggregatesAreVisible();
+    await map.areAdminBoundariesVisible({ layerName: 'population_affected' });
     // Validate rest of the map
     await map.validateLayerIsVisibleInMapBySrcElement({
       layerName: 'flood_extent',

--- a/tests/e2e/tests/MapComponent/MapComponentLayersDefault.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentLayersDefault.ts
@@ -44,7 +44,7 @@ export default (
       legendComponentName: 'Exposed population',
     });
     // Validate that the layer checked with radio button is visible on the map in this case 'Exposed population' only one such layer can be checked at a time
-    await map.validateAggregatePaneIsNotEmpty();
+    await map.validateAggregatesAreVisible();
     // Validate rest of the map
     await map.validateLayerIsVisibleInMapBySrcElement({
       layerName: 'flood_extent',

--- a/tests/e2e/tests/MapComponent/MapComponentLayersDefault.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentLayersDefault.ts
@@ -49,9 +49,5 @@ export default (
     await map.validateLayerIsVisibleInMapBySrcElement({
       layerName: 'flood_extent',
     });
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/MapComponent/MapComponentLayersDefault.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentLayersDefault.ts
@@ -29,11 +29,11 @@ export default (
 
     await map.clickLayerMenu();
     await map.isLayerMenuOpen({ layerMenuOpen: true });
-    await map.verifyLayerCheckboxCheckedByName({
-      layerName: 'Flood extent',
+    await map.isLayerCheckboxChecked({
+      layerName: 'flood_extent',
     });
-    await map.verifyLayerRadioButtonCheckedByName({
-      layerName: 'Exposed population',
+    await map.isLayerRadioButtonChecked({
+      layerName: 'population_affected',
     });
     // Validate legend
     await map.isLegendOpen({ legendOpen: true });

--- a/tests/e2e/tests/MapComponent/MapComponentLayersVisible.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentLayersVisible.ts
@@ -32,11 +32,8 @@ export default (
     await map.isLayerMenuOpen({ layerMenuOpen: true });
 
     // Check if the default layers are visible
-    const activeLayers = ACTIVE_LAYERS[disasterType];
-    if (activeLayers) {
-      await map.validateLayersAreVisibleByName({ layerNames: activeLayers });
-    } else {
-      throw new Error('No layers are visible');
+    for (const layerName in ACTIVE_LAYERS[disasterType]) {
+      await map.isLayerVisible({ layerName });
     }
 
     // Reload the page to prepare for next test

--- a/tests/e2e/tests/MapComponent/MapComponentLayersVisible.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentLayersVisible.ts
@@ -35,9 +35,5 @@ export default (
     for (const layerName in ACTIVE_LAYERS[disasterType]) {
       await map.isLayerVisible({ layerName });
     }
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/MapComponent/MapComponentTriggerLayer.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentTriggerLayer.ts
@@ -31,9 +31,5 @@ export default (
       legendComponentName: 'Area triggered',
     });
     await map.assertTriggerOutlines({ visible: false });
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/MapComponent/MapComponentVisible.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentVisible.ts
@@ -27,9 +27,5 @@ export default (
     await map.isLegendOpen({ legendOpen: true });
     await map.isLayerMenuOpen({ layerMenuOpen: false });
     await map.areAdminBoundariesVisible();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/MapComponent/MapComponentVisible.ts
+++ b/tests/e2e/tests/MapComponent/MapComponentVisible.ts
@@ -26,7 +26,7 @@ export default (
     await map.breadCrumbViewIsVisible({ nationalView: true });
     await map.isLegendOpen({ legendOpen: true });
     await map.isLayerMenuOpen({ layerMenuOpen: false });
-    await map.assertAdminBoundariesVisible();
+    await map.areAdminBoundariesVisible();
 
     // Reload the page to prepare for next test
     await dashboard.page.goto('/');

--- a/tests/e2e/tests/ScenarioNoTrigger.spec.ts
+++ b/tests/e2e/tests/ScenarioNoTrigger.spec.ts
@@ -70,6 +70,10 @@ test.describe('Scenario: No Trigger', () => {
     );
   });
 
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
   test.afterAll(async () => {
     await page.close();
   });

--- a/tests/e2e/tests/ScenarioTrigger.spec.ts
+++ b/tests/e2e/tests/ScenarioTrigger.spec.ts
@@ -63,6 +63,10 @@ test.describe('Scenario: Trigger', () => {
     );
   });
 
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
   test.afterAll(async () => {
     await page.close();
   });

--- a/tests/e2e/tests/TimelineComponent/TimelineComponentDisabled.ts
+++ b/tests/e2e/tests/TimelineComponent/TimelineComponentDisabled.ts
@@ -23,9 +23,5 @@ export default (
       countryName: NoTriggerDataSet.CountryName,
     });
     await timeline.timelineIsInactive();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/TimelineComponent/TimelineComponentNotClickable.ts
+++ b/tests/e2e/tests/TimelineComponent/TimelineComponentNotClickable.ts
@@ -27,9 +27,5 @@ export default (
     });
     await timeline.validateTimelineDates();
     await timeline.assertPurpleTimelineButtonElements();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/TimelineComponent/TimelineComponentVisible.ts
+++ b/tests/e2e/tests/TimelineComponent/TimelineComponentVisible.ts
@@ -23,9 +23,5 @@ export default (
       countryName: NoTriggerDataSet.CountryName,
     });
     await timeline.timlineElementsAreVisible();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/UserStateComponent/UserStateComponentLogout.ts
+++ b/tests/e2e/tests/UserStateComponent/UserStateComponentLogout.ts
@@ -24,9 +24,5 @@ export default (
     });
     await userState.logOut();
     await login.loginScreenIsVisible();
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };

--- a/tests/e2e/tests/UserStateComponent/UserStateComponentVisible.ts
+++ b/tests/e2e/tests/UserStateComponent/UserStateComponentVisible.ts
@@ -26,9 +26,5 @@ export default (
       firstName: NoTriggerDataSet.firstName,
       lastName: NoTriggerDataSet.lastName,
     });
-
-    // Reload the page to prepare for next test
-    await dashboard.page.goto('/');
-    await dashboard.page.waitForTimeout(1000);
   });
 };


### PR DESCRIPTION
## Describe your changes

I created this PR only after all the tests ran 3 consecutive times without any failures. It includes,
1. Use specific selectors to identify UI elements. For example, use `.admin-boundary` instead of `.leaflet-interactive` to hover over admin boundary polygons. It used to include GloFAS markers as they are also interactive leaflet elements.
2. Modify tests so as not to skip necessary UI actions. In the case of opening info popups, the test should explicitly close the popup after assertions by clicking on the backdrop.
3. Remove most timeouts. The timeouts did not reduce the flakiness. A few timeouts remain because I had to stop refactoring tests at some point.

I'm now certain that flaky tests can be completely avoided. The reasons for flakiness are varied. My understanding of the user interface significantly helped identify some causes. Playwright also has unexpected behaviours based on how and where we use locators. Some tests became stable by defining the locator at the time of the assertion (instead of the page constructor). We're learning this together and it looks promising that we will achieve a suite of stable test cases which scale across countries and hazards.

@Piotrk39 For future tests, please check with me before you add any timeouts or selectors/locators. I noticed code evidence of the impossible task we're putting you through. Your work so far is impressive, well done 👏 🏆 🥇

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review

