### PR TITLE
feat: add noNotifications query param to POST /events/process

### DIFF
--- a/services/API-service/src/api/process-pipeline/process-pipeline.controller.ts
+++ b/services/API-service/src/api/process-pipeline/process-pipeline.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  HttpCode,
   ParseBoolPipe,
   Post,
   Query,
@@ -61,16 +62,32 @@ export class ProcessPipelineController {
       'Process events for given country and disaster-type. Must be run at end of every pipeline.',
   })
   @ApiResponse({
-    status: 201,
+    status: 200,
     description: 'Processed events.',
   })
+  @ApiQuery({
+    name: 'noNotifications',
+    required: false,
+    schema: { default: false, type: 'boolean' },
+    type: 'boolean',
+    description: 'If true, returns the notification content without sending it',
+  })
   @Post('events/process')
+  @HttpCode(200)
   public async processEvents(
     @Body() processEventsDto: ProcessEventsDto,
-  ): Promise<void> {
-    await this.processPipelineService.processEvents(
+    @Query(
+      'noNotifications',
+      new ParseBoolPipe({
+        optional: true,
+      }),
+    )
+    noNotifications: boolean,
+  ): Promise<void | NotificationApiTestResponseDto> {
+    return await this.processPipelineService.processEvents(
       processEventsDto.countryCodeISO3,
       processEventsDto.disasterType,
+      noNotifications,
     );
   }
 

--- a/services/API-service/src/api/process-pipeline/process-pipeline.service.ts
+++ b/services/API-service/src/api/process-pipeline/process-pipeline.service.ts
@@ -17,7 +17,7 @@ export class ProcessPipelineService {
   public async processEvents(
     countryCodeISO3: string,
     disasterType: DisasterType,
-    noNotifications = false,
+    noNotifications: boolean,
   ): Promise<void | NotificationApiTestResponseDto> {
     const lastUploadDate = await this.helperService.getLastUploadDate(
       countryCodeISO3,

--- a/tests/integration/helpers/API-service/dto/events-process.dto.ts
+++ b/tests/integration/helpers/API-service/dto/events-process.dto.ts
@@ -1,0 +1,7 @@
+import { DisasterType } from '../enum/disaster-type.enum';
+
+export interface EventsProcessDto {
+  countryCodeISO3: string;
+  disasterType: DisasterType;
+  readonly date: Date;
+}

--- a/tests/integration/helpers/utility.helper.ts
+++ b/tests/integration/helpers/utility.helper.ts
@@ -2,6 +2,7 @@ import * as request from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
 import { CreateUserDto } from './API-service/dto/create-user.dto';
+import { EventsProcessDto } from './API-service/dto/events-process.dto';
 import { UpdateUserDto } from './API-service/dto/update-user.dto';
 import { CommunityNotificationExternalDto } from './API-service/dto/upload-community-notification.dto';
 import { UploadTyphoonTrackDto } from './API-service/dto/upload-typhoon-track.dto';
@@ -166,6 +167,18 @@ export function getEventsSummary(
   return getServer()
     .get(`/event/${countryCodeISO3}/${disasterType}`)
     .set('Authorization', `Bearer ${accessToken}`);
+}
+
+export function postEventsProcess(
+  eventsProcessDto: EventsProcessDto,
+  noNotifications: boolean,
+  accessToken: string,
+): Promise<request.Response> {
+  return getServer()
+    .post(`/events/process`)
+    .query({ noNotifications })
+    .set('Authorization', `Bearer ${accessToken}`)
+    .send(eventsProcessDto);
 }
 
 export function postCommunityNotification(

--- a/tests/integration/tests/events/process.test.ts
+++ b/tests/integration/tests/events/process.test.ts
@@ -1,0 +1,69 @@
+import { DisasterType } from '../../helpers/API-service/enum/disaster-type.enum';
+import { FloodsScenario } from '../../helpers/API-service/enum/mock-scenario.enum';
+import {
+  getAccessToken,
+  mock,
+  postEventsProcess,
+  resetDB,
+} from '../../helpers/utility.helper';
+
+const eventsProcessDto = {
+  countryCodeISO3: 'UGA',
+  disasterType: DisasterType.Floods,
+  date: new Date(),
+};
+
+describe('events', () => {
+  let accessToken: string;
+
+  beforeAll(async () => {
+    accessToken = await getAccessToken();
+    await resetDB(accessToken);
+  });
+
+  describe('process', () => {
+    it('returns notification content if noNotification is true', async () => {
+      // Arrange
+      await mock(
+        FloodsScenario.Trigger,
+        DisasterType.Floods,
+        'UGA',
+        null,
+        accessToken,
+      );
+
+      // Act
+      const result = await postEventsProcess(
+        eventsProcessDto,
+        true,
+        accessToken,
+      );
+
+      // Assert
+      expect(result.status).toBe(200);
+      expect(result.body.activeEvents.email).toBeTruthy();
+    });
+
+    it('returns void if noNotification is false', async () => {
+      // Arrange
+      await mock(
+        FloodsScenario.Trigger,
+        DisasterType.Floods,
+        'UGA',
+        null,
+        accessToken,
+      );
+
+      // Act
+      const result = await postEventsProcess(
+        eventsProcessDto,
+        false,
+        accessToken,
+      );
+
+      // Assert
+      expect(result.status).toBe(200);
+      expect(result.body).toMatchObject({});
+    });
+  });
+});

--- a/tests/integration/tests/events/process.test.ts
+++ b/tests/integration/tests/events/process.test.ts
@@ -21,49 +21,43 @@ describe('events', () => {
     await resetDB(accessToken);
   });
 
-  describe('process', () => {
-    it('returns notification content if noNotification is true', async () => {
-      // Arrange
-      await mock(
-        FloodsScenario.Trigger,
-        DisasterType.Floods,
-        'UGA',
-        null,
-        accessToken,
-      );
+  it('process returns notification content if noNotification is true', async () => {
+    // Arrange
+    await mock(
+      FloodsScenario.Trigger,
+      DisasterType.Floods,
+      'UGA',
+      null,
+      accessToken,
+    );
 
-      // Act
-      const result = await postEventsProcess(
-        eventsProcessDto,
-        true,
-        accessToken,
-      );
+    // Act
+    const result = await postEventsProcess(eventsProcessDto, true, accessToken);
 
-      // Assert
-      expect(result.status).toBe(200);
-      expect(result.body.activeEvents.email).toBeTruthy();
-    });
+    // Assert
+    expect(result.status).toBe(200);
+    expect(result.body.activeEvents.email).toBeTruthy();
+  });
 
-    it('returns void if noNotification is false', async () => {
-      // Arrange
-      await mock(
-        FloodsScenario.Trigger,
-        DisasterType.Floods,
-        'UGA',
-        null,
-        accessToken,
-      );
+  it('process returns void if noNotification is false', async () => {
+    // Arrange
+    await mock(
+      FloodsScenario.Trigger,
+      DisasterType.Floods,
+      'UGA',
+      null,
+      accessToken,
+    );
 
-      // Act
-      const result = await postEventsProcess(
-        eventsProcessDto,
-        false,
-        accessToken,
-      );
+    // Act
+    const result = await postEventsProcess(
+      eventsProcessDto,
+      false,
+      accessToken,
+    );
 
-      // Assert
-      expect(result.status).toBe(200);
-      expect(result.body).toMatchObject({});
-    });
+    // Assert
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({});
   });
 });


### PR DESCRIPTION
## Describe your changes

This PR adds `noNotifications` to `POST /events/process` events.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review

## Notes for the reviewer

[Context](https://teams.microsoft.com/l/message/19:bdb9d621f18c48c7917e545bf6d7aabe@thread.v2/1740756319179?context=%7B%22contextType%22%3A%22chat%22%7D)