### PR TITLE
fix: change close-events api path typo AB#34185

### DIFF
--- a/services/API-service/src/api/process-pipeline/process-pipeline.controller.ts
+++ b/services/API-service/src/api/process-pipeline/process-pipeline.controller.ts
@@ -43,7 +43,7 @@ export class ProcessPipelineController {
     status: 201,
     description: 'Closed finished events.',
   })
-  @Post('events/close-events')
+  @Post('event/close-events')
   public async closeEvents(
     @Body() closeEventsDto: ProcessEventsDto,
   ): Promise<void> {


### PR DESCRIPTION
## Describe your changes

Floods pipeline failed because api path changed from /event/close-events to /events/close-events (plural in first part).
This is changed in this PR.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review


