### PR TITLE
feat: unset warning

### DIFF
--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.html
@@ -77,24 +77,21 @@
         }}
       </strong>
       <span>{{ event.nrAlertAreas + ' ' }}</span>
-      @if (mainExposureIndicatorNumberFormat !== 'perc') {
-        @if (event.mainExposureValueSum) {
-          <span>{{
-            '(' +
-              (mainExposureIndicatorLabel | titlecase) +
-              ' ' +
-              (event.mainExposureValueSum | compact) +
-              ')'
-          }}</span>
-        } @else {
-          <span>
-            {{
-              '(' +
-                ('chat-component.common.alertLevel.no-data' | translate) +
-                ')'
-            }}
-          </span>
-        }
+      @if (event.mainExposureValueSum) {
+        <span>{{
+          '(' +
+            (mainExposureIndicatorLabel | titlecase) +
+            ' ' +
+            (event.mainExposureValueSum
+              | compact: mainExposureIndicatorNumberFormat) +
+            ')'
+        }}</span>
+      } @else {
+        <span>
+          {{
+            '(' + ('chat-component.common.alertLevel.no-data' | translate) + ')'
+          }}
+        </span>
       }
     </p>
 

--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.ts
@@ -76,11 +76,30 @@ export class EventSpeechBubbleComponent implements AfterViewChecked, OnDestroy {
 
     if (this.event) {
       this.event.header = this.getHeader(this.event);
+      this.event.mainExposureValueSum = this.getEventMainExposureValue(
+        this.event,
+        this.mainExposureIndicatorNumberFormat,
+      );
     }
   }
 
   ngOnDestroy() {
     this.placeCodeHoverSubscription.unsubscribe();
+  }
+
+  private getEventMainExposureValue(
+    event: EventSummary,
+    mainExposureIndicatorNumberFormat: NumberFormat,
+  ) {
+    const sum = event.alertAreas?.reduce(
+      (acc, alertArea) => acc + alertArea.mainExposureValue,
+      0,
+    );
+    // NOTE: this is a temporary solution, as this actually needs a weighted average. At least this is better than sum.
+    if (mainExposureIndicatorNumberFormat === NumberFormat.perc) {
+      return sum / event.alertAreas?.length || 1;
+    }
+    return sum;
   }
 
   public selectArea(area: AlertArea) {

--- a/interfaces/IBF-dashboard/src/app/components/timeline/timeline.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/timeline/timeline.component.ts
@@ -1,11 +1,9 @@
 import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { PlaceCode } from 'src/app/models/place-code.model';
-import { DisasterTypeService } from 'src/app/services/disaster-type.service';
 import { EventService } from 'src/app/services/event.service';
 import { PlaceCodeService } from 'src/app/services/place-code.service';
 import { TimelineService } from 'src/app/services/timeline.service';
-import { DisasterTypeKey } from 'src/app/types/disaster-type-key';
 import { TimelineState } from 'src/app/types/timeline-state';
 
 @Component({
@@ -24,7 +22,6 @@ export class TimelineComponent implements OnInit, OnDestroy {
   constructor(
     public timelineService: TimelineService,
     private eventService: EventService,
-    private disasterTypeService: DisasterTypeService,
     private placeCodeService: PlaceCodeService,
     private changeDetectorRef: ChangeDetectorRef,
   ) {}
@@ -50,11 +47,7 @@ export class TimelineComponent implements OnInit, OnDestroy {
   };
 
   private onPlaceCodeHoverChange = (placeCode: PlaceCode) => {
-    if (
-      !this.eventService.state.event &&
-      this.disasterTypeService?.disasterType?.disasterType !==
-        DisasterTypeKey.flashFloods
-    ) {
+    if (!this.eventService.state.event) {
       this.placeCodeHover = placeCode;
       if (this.placeCodeHover) {
         const btns = this.timelineState?.timeStepButtons?.filter((t) =>

--- a/interfaces/IBF-dashboard/src/app/mocks/event-state.mock.ts
+++ b/interfaces/IBF-dashboard/src/app/mocks/event-state.mock.ts
@@ -1,3 +1,4 @@
+import { MOCK_ALERT_AREAS } from 'src/app/mocks/alert-areas.mock';
 import { AlertLevel, EventSummary } from 'src/app/services/event.service';
 import { EventState } from 'src/app/types/event-state';
 
@@ -12,6 +13,7 @@ const MOCK_EVENT: EventSummary = {
   userTrigger: false,
   userTriggerDate: null,
   userTriggerName: null,
+  alertAreas: MOCK_ALERT_AREAS,
 };
 export const MOCK_EVENT_STATE: EventState = {
   events: [MOCK_EVENT, MOCK_EVENT],

--- a/interfaces/IBF-dashboard/src/app/services/api.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/api.service.ts
@@ -11,7 +11,6 @@ import { EventSummary } from 'src/app/services/event.service';
 import { JwtService } from 'src/app/services/jwt.service';
 import { AdminLevel } from 'src/app/types/admin-level';
 import { AggregateRecord } from 'src/app/types/aggregate';
-import { AlertArea } from 'src/app/types/alert-area';
 import { DisasterTypeKey } from 'src/app/types/disaster-type-key';
 import { IbfLayerMetadata, IbfLayerName } from 'src/app/types/ibf-layer';
 import { Indicator } from 'src/app/types/indicator-group';
@@ -271,23 +270,6 @@ export class ApiService {
     }
     return this.get(
       `admin-areas/aggregates/${countryCodeISO3}/${disasterType}/${adminLevel.toString()}`,
-      false,
-      params,
-    );
-  }
-
-  getAlertAreas(
-    countryCodeISO3: string,
-    disasterType: DisasterTypeKey,
-    adminLevel: number,
-    eventName: string,
-  ): Observable<AlertArea[]> {
-    let params = new HttpParams();
-    if (eventName) {
-      params = params.append('eventName', eventName);
-    }
-    return this.get(
-      `event/alert-areas/${countryCodeISO3}/${adminLevel.toString()}/${disasterType}`,
       false,
       params,
     );

--- a/interfaces/IBF-dashboard/src/app/services/event.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/event.service.ts
@@ -15,6 +15,7 @@ import {
 import { ApiService } from 'src/app/services/api.service';
 import { CountryService } from 'src/app/services/country.service';
 import { DisasterTypeService } from 'src/app/services/disaster-type.service';
+import { AlertArea } from 'src/app/types/alert-area';
 import { DisasterTypeKey } from 'src/app/types/disaster-type-key';
 import { EventState } from 'src/app/types/event-state';
 import { LastUploadDate } from 'src/app/types/last-upload-date';
@@ -39,6 +40,7 @@ export class EventSummary {
   duration?: number;
   disasterSpecificProperties: DisasterSpecificProperties;
   header?: string;
+  alertAreas?: AlertArea[];
   nrAlertAreas?: number;
   mainExposureValueSum?: number;
   alertLevel: AlertLevel;
@@ -240,6 +242,7 @@ export class EventService {
           : null;
 
         event.duration = this.getEventDuration(event);
+        event.nrAlertAreas = event.alertAreas?.length;
       }
     }
 

--- a/interfaces/IBF-dashboard/src/assets/i18n/en.json
+++ b/interfaces/IBF-dashboard/src/assets/i18n/en.json
@@ -180,8 +180,8 @@
       "active-event": {
         "header": "Trigger: {{ eventName }} in {{firstLeadTimeDate}}",
         "header-below-trigger": "Warning: {{ eventName }} on {{firstLeadTimeDate}}",
-        "header-ongoing": "Ongoing trigger: {{eventName}} in {{firstLeadTimeDate}}",
-        "header-ongoing-below-trigger": "Ongoing warning: {{eventName}} in {{firstLeadTimeDate}}",
+        "header-ongoing": "Ongoing trigger: {{eventName}}",
+        "header-ongoing-below-trigger": "Ongoing warning: {{eventName}}",
         "place-name": "{{ adminAreaLabel }}: <strong>{{ placeName }}</strong>{{ parentName }}",
         "exposed": "Exposed Population:"
       },

--- a/interfaces/IBF-dashboard/src/assets/i18n/en.json
+++ b/interfaces/IBF-dashboard/src/assets/i18n/en.json
@@ -180,8 +180,8 @@
       "active-event": {
         "header": "Trigger: {{ eventName }} in {{firstLeadTimeDate}}",
         "header-below-trigger": "Warning: {{ eventName }} on {{firstLeadTimeDate}}",
-        "header-ongoing": "Ongoing trigger: {{eventName}}",
-        "header-ongoing-below-trigger": "Ongoing warning: {{eventName}}",
+        "header-ongoing": "Trigger: {{eventName}}, ongoing",
+        "header-ongoing-below-trigger": "Warning: {{eventName}}, ongoing",
         "place-name": "{{ adminAreaLabel }}: <strong>{{ placeName }}</strong>{{ parentName }}",
         "exposed": "Exposed Population:"
       },

--- a/services/API-service/module-dependencies.md
+++ b/services/API-service/module-dependencies.md
@@ -21,6 +21,7 @@ graph LR
   MetadataModule-->CountryModule
   MetadataModule-->DisasterTypeModule
   AdminAreaModule-->CountryModule
+  AdminAreaModule-->DisasterTypeModule
   AdminAreaDynamicDataModule-->UserModule
   AdminAreaDynamicDataModule-->EventModule
   AdminAreaDynamicDataModule-->CountryModule

--- a/services/API-service/module-dependencies.md
+++ b/services/API-service/module-dependencies.md
@@ -14,12 +14,17 @@ graph LR
   EventModule-->EapActionsModule
   EventModule-->TyphoonTrackModule
   TyphoonTrackModule-->UserModule
+  EventModule-->DisasterTypeModule
+  DisasterTypeModule-->UserModule
+  EventModule-->MetadataModule
+  MetadataModule-->UserModule
+  MetadataModule-->CountryModule
+  MetadataModule-->DisasterTypeModule
   AdminAreaModule-->CountryModule
   AdminAreaDynamicDataModule-->UserModule
   AdminAreaDynamicDataModule-->EventModule
   AdminAreaDynamicDataModule-->CountryModule
   AdminAreaDynamicDataModule-->AdminAreaModule
-  DisasterTypeModule-->UserModule
   ProcessPipelineModule-->UserModule
   ProcessPipelineModule-->EventModule
   ProcessPipelineModule-->NotificationModule
@@ -33,11 +38,11 @@ graph LR
   NotificationContentModule-->AdminAreaDataModule
   AdminAreaDataModule-->UserModule
   NotificationContentModule-->AdminAreaModule
+  NotificationContentModule-->DisasterTypeModule
+  NotificationContentModule-->MetadataModule
+  WhatsappModule-->MetadataModule
   NotificationModule-->NotificationContentModule
   NotificationModule-->TyphoonTrackModule
-  MetadataModule-->UserModule
-  MetadataModule-->CountryModule
-  MetadataModule-->EventModule
   PointDataModule-->UserModule
   PointDataModule-->WhatsappModule
   LinesDataModule-->UserModule

--- a/services/API-service/src/api/admin-area/admin-area.module.ts
+++ b/services/API-service/src/api/admin-area/admin-area.module.ts
@@ -6,6 +6,7 @@ import { HelperService } from '../../shared/helper.service';
 import { AdminAreaDynamicDataEntity } from '../admin-area-dynamic-data/admin-area-dynamic-data.entity';
 import { CountryEntity } from '../country/country.entity';
 import { DisasterTypeEntity } from '../disaster-type/disaster-type.entity';
+import { DisasterTypeModule } from '../disaster-type/disaster-type.module';
 import { EventModule } from '../event/event.module';
 import { UserModule } from '../user/user.module';
 import { CountryModule } from './../country/country.module';
@@ -28,6 +29,7 @@ import { EventAreaService } from './services/event-area.service';
     ]),
     EventModule,
     CountryModule,
+    DisasterTypeModule,
   ],
   providers: [AdminAreaService, EventAreaService, HelperService],
   controllers: [AdminAreaController],

--- a/services/API-service/src/api/admin-area/admin-area.service.ts
+++ b/services/API-service/src/api/admin-area/admin-area.service.ts
@@ -12,6 +12,7 @@ import { DynamicIndicator } from '../admin-area-dynamic-data/enum/dynamic-indica
 import { LeadTime } from '../admin-area-dynamic-data/enum/lead-time.enum';
 import { DisasterTypeEntity } from '../disaster-type/disaster-type.entity';
 import { DisasterType } from '../disaster-type/disaster-type.enum';
+import { DisasterTypeService } from '../disaster-type/disaster-type.service';
 import { LastUploadDateDto } from '../event/dto/last-upload-date.dto';
 import { EventPlaceCodeEntity } from '../event/event-place-code.entity';
 import { EventService } from '../event/event.service';
@@ -31,6 +32,7 @@ export class AdminAreaService {
     private helperService: HelperService,
     private eventService: EventService,
     private eventAreaService: EventAreaService,
+    private disasterTypeService: DisasterTypeService,
   ) {}
 
   public async addOrUpdateAdminAreas(
@@ -253,12 +255,6 @@ export class AdminAreaService {
     return staticIndicators.concat(dynamicIndicators);
   }
 
-  private async getDisasterType(
-    disasterType: DisasterType,
-  ): Promise<DisasterTypeEntity> {
-    return this.disasterTypeRepository.findOne({ where: { disasterType } });
-  }
-
   public async getAdminAreasRaw(countryCodeISO3: string) {
     return await this.adminAreaRepository.find({
       select: [
@@ -281,7 +277,8 @@ export class AdminAreaService {
     eventName: string,
     placeCodeParent?: string,
   ): Promise<GeoJson> {
-    const disasterTypeEntity = await this.getDisasterType(disasterType);
+    const disasterTypeEntity =
+      await this.disasterTypeService.getDisasterType(disasterType);
     const lastUploadDate = await this.helperService.getLastUploadDate(
       countryCodeISO3,
       disasterType,

--- a/services/API-service/src/api/admin-area/admin-area.service.ts
+++ b/services/API-service/src/api/admin-area/admin-area.service.ts
@@ -373,10 +373,11 @@ export class AdminAreaService {
     adminAreas.forEach((area) => {
       area.alertLevel = this.eventService.getAlertLevel(area);
     });
-    const highestAlertLevel =
-      this.eventService.getHighestAlertLevel(adminAreas);
+    const highestAlertLevels =
+      this.eventService.getHighestAlertLevelPerEvent(adminAreas);
     adminAreas = adminAreas.filter(
-      ({ alertLevel }) => alertLevel === highestAlertLevel,
+      (area) =>
+        area.alertLevel === highestAlertLevels[area.eventName || 'unknown'],
     );
     return this.helperService.toGeojson(adminAreas);
   }

--- a/services/API-service/src/api/admin-area/admin-area.service.ts
+++ b/services/API-service/src/api/admin-area/admin-area.service.ts
@@ -372,10 +372,15 @@ export class AdminAreaService {
       );
     }
 
-    const adminAreas = await adminAreasScript.getRawMany();
+    let adminAreas = await adminAreasScript.getRawMany();
     adminAreas.forEach((area) => {
       area.alertLevel = this.eventService.getAlertLevel(area);
     });
+    const highestAlertLevel =
+      this.eventService.getHighestAlertLevel(adminAreas);
+    adminAreas = adminAreas.filter(
+      ({ alertLevel }) => alertLevel === highestAlertLevel,
+    );
     return this.helperService.toGeojson(adminAreas);
   }
 

--- a/services/API-service/src/api/disaster-type/disaster-type.service.ts
+++ b/services/API-service/src/api/disaster-type/disaster-type.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { DisasterTypeEntity } from './disaster-type.entity';
+import { DisasterType } from './disaster-type.enum';
 import {
   AddDisasterTypesDto,
   DisasterTypeDto,
@@ -13,6 +14,25 @@ import {
 export class DisasterTypeService {
   @InjectRepository(DisasterTypeEntity)
   private readonly disasterTypeRepository: Repository<DisasterTypeEntity>;
+
+  public async getDisasterType(
+    disasterType: DisasterType,
+  ): Promise<DisasterTypeEntity> {
+    return await this.disasterTypeRepository.findOne({
+      where: { disasterType },
+    });
+  }
+
+  public async getMainExposureIndicator(
+    disasterType: DisasterType,
+  ): Promise<string> {
+    return (
+      await this.disasterTypeRepository.findOne({
+        select: ['mainExposureIndicator'],
+        where: { disasterType },
+      })
+    ).mainExposureIndicator;
+  }
 
   public async addOrUpdateDisasterTypes(
     disasterTypes: AddDisasterTypesDto,

--- a/services/API-service/src/api/event/enum/alert-level.enum.ts
+++ b/services/API-service/src/api/event/enum/alert-level.enum.ts
@@ -11,3 +11,11 @@ export const ALERT_LEVEL_WARNINGS = [
   AlertLevel.WARNINGMEDIUM,
   AlertLevel.WARNING,
 ];
+
+export const ALERT_LEVEL_RANK: Record<AlertLevel, number> = {
+  [AlertLevel.NONE]: 0,
+  [AlertLevel.WARNINGLOW]: 1,
+  [AlertLevel.WARNINGMEDIUM]: 2,
+  [AlertLevel.WARNING]: 3,
+  [AlertLevel.TRIGGER]: 4,
+};

--- a/services/API-service/src/api/event/event.controller.ts
+++ b/services/API-service/src/api/event/event.controller.ts
@@ -20,7 +20,7 @@ import { UpdateResult } from 'typeorm';
 
 import { Roles } from '../../roles.decorator';
 import { RolesGuard } from '../../roles.guard';
-import { AlertArea, EventSummaryCountry } from '../../shared/data.model';
+import { EventSummaryCountry } from '../../shared/data.model';
 import { DisasterType } from '../disaster-type/disaster-type.enum';
 import { UserRole } from '../user/user-role.enum';
 import { UserDecorator } from '../user/user.decorator';
@@ -110,34 +110,6 @@ export class EventController {
     return await this.eventService.getAlertPerLeadTime(
       params.countryCodeISO3,
       params.disasterType,
-      query.eventName,
-    );
-  }
-
-  @UseGuards(RolesGuard)
-  @ApiOperation({
-    summary:
-      'Get alerted admin-areas for given country, disaster-type, admin-level (and event-name).',
-  })
-  @ApiParam({ name: 'countryCodeISO3', required: true, type: 'string' })
-  @ApiParam({ name: 'disasterType', required: true, enum: DisasterType })
-  @ApiParam({ name: 'adminLevel', required: true, type: 'number' })
-  @ApiQuery({ name: 'eventName', required: false, type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description:
-      'Alerted admin-areas for given country, disaster-type, admin-level (and event-name).',
-    type: [AlertArea],
-  })
-  @Get('alert-areas/:countryCodeISO3/:adminLevel/:disasterType')
-  public async getAlertAreas(
-    @Param() params,
-    @Query() query,
-  ): Promise<AlertArea[]> {
-    return await this.eventService.getAlertAreas(
-      params.countryCodeISO3,
-      params.disasterType,
-      params.adminLevel,
       query.eventName,
     );
   }

--- a/services/API-service/src/api/event/event.module.ts
+++ b/services/API-service/src/api/event/event.module.ts
@@ -6,6 +6,8 @@ import { AdminAreaDynamicDataEntity } from '../admin-area-dynamic-data/admin-are
 import { AdminAreaEntity } from '../admin-area/admin-area.entity';
 import { CountryEntity } from '../country/country.entity';
 import { DisasterTypeEntity } from '../disaster-type/disaster-type.entity';
+import { DisasterTypeModule } from '../disaster-type/disaster-type.module';
+import { MetadataModule } from '../metadata/metadata.module';
 import { TyphoonTrackModule } from '../typhoon-track/typhoon-track.module';
 import { UserEntity } from '../user/user.entity';
 import { CountryModule } from './../country/country.module';
@@ -22,6 +24,8 @@ import { EventService } from './event.service';
     CountryModule,
     EapActionsModule,
     TyphoonTrackModule,
+    DisasterTypeModule,
+    MetadataModule,
     TypeOrmModule.forFeature([
       EventPlaceCodeEntity,
       AlertPerLeadTimeEntity,

--- a/services/API-service/src/api/event/event.service.spec.ts
+++ b/services/API-service/src/api/event/event.service.spec.ts
@@ -9,6 +9,7 @@ import { AdminAreaDynamicDataEntity } from '../admin-area-dynamic-data/admin-are
 import { AdminAreaEntity } from '../admin-area/admin-area.entity';
 import { CountryEntity } from '../country/country.entity';
 import { DisasterTypeEntity } from '../disaster-type/disaster-type.entity';
+import { DisasterTypeService } from '../disaster-type/disaster-type.service';
 import { EapActionsService } from '../eap-actions/eap-actions.service';
 import { TyphoonTrackService } from '../typhoon-track/typhoon-track.service';
 import { AlertPerLeadTimeEntity } from './alert-per-lead-time.entity';
@@ -25,34 +26,23 @@ describe('EventService', () => {
         EventService,
         {
           provide: EapActionsService,
-          useValue: {
-            // Mock methods of EapActionsService that are used in EventService
-          },
+          useValue: {},
+        },
+        {
+          provide: DisasterTypeService,
+          useValue: {},
         },
         {
           provide: HelperService,
-          useValue: {
-            // Mock methods of HelperService that are used in EventService
-          },
+          useValue: {},
         },
         {
           provide: TyphoonTrackService,
-          useValue: {
-            // Mock methods of TyphoonTrackService that are used in EventService
-          },
+          useValue: {},
         },
         {
           provide: DataSource,
-          useValue: {
-            // Mock DataSource methods if they are used in EventService
-            // createQueryRunner: jest.fn().mockReturnValue({
-            //   connect: jest.fn(),
-            //   startTransaction: jest.fn(),
-            //   commitTransaction: jest.fn(),
-            //   rollbackTransaction: jest.fn(),
-            //   release: jest.fn(),
-            // }),
-          },
+          useValue: {},
         },
         {
           provide: getRepositoryToken(EventPlaceCodeEntity),

--- a/services/API-service/src/api/event/event.service.spec.ts
+++ b/services/API-service/src/api/event/event.service.spec.ts
@@ -11,6 +11,7 @@ import { CountryEntity } from '../country/country.entity';
 import { DisasterTypeEntity } from '../disaster-type/disaster-type.entity';
 import { DisasterTypeService } from '../disaster-type/disaster-type.service';
 import { EapActionsService } from '../eap-actions/eap-actions.service';
+import { MetadataService } from '../metadata/metadata.service';
 import { TyphoonTrackService } from '../typhoon-track/typhoon-track.service';
 import { AlertPerLeadTimeEntity } from './alert-per-lead-time.entity';
 import { EventPlaceCodeEntity } from './event-place-code.entity';
@@ -30,6 +31,10 @@ describe('EventService', () => {
         },
         {
           provide: DisasterTypeService,
+          useValue: {},
+        },
+        {
+          provide: MetadataService,
           useValue: {},
         },
         {

--- a/services/API-service/src/api/event/event.service.ts
+++ b/services/API-service/src/api/event/event.service.ts
@@ -597,9 +597,7 @@ export class EventService {
     return areas.filter(({ alertLevel }) => alertLevel === highestAlertLevel);
   }
 
-  private getHighestAlertLevel(
-    areas: { alertLevel: AlertLevel }[],
-  ): AlertLevel {
+  public getHighestAlertLevel(areas: { alertLevel: AlertLevel }[]): AlertLevel {
     return areas.reduce((highest: AlertLevel, area: AlertArea) => {
       return ALERT_LEVEL_RANK[area.alertLevel] > ALERT_LEVEL_RANK[highest]
         ? area.alertLevel

--- a/services/API-service/src/api/event/event.service.ts
+++ b/services/API-service/src/api/event/event.service.ts
@@ -200,8 +200,8 @@ export class EventService {
       mainExposureValueSum: 0,
     };
 
-    const indicator =
-      await this.metadataService.getIndicatorMetadata(disasterType);
+    const mainExposureIndicatorMetadata =
+      await this.metadataService.getMainExposureIndicatorMetadata(disasterType);
 
     const epcQuery = this.eventPlaceCodeRepo
       .createQueryBuilder('epc')
@@ -243,9 +243,8 @@ export class EventService {
         warning.mainExposureValueSum;
     }
 
-    if (indicator.numberFormatMap === NumberFormat.perc) {
-      // return average of percentages for percentage indicator
-      // NOTE: this is a temporary solution, as we should not be summing percentages
+    if (mainExposureIndicatorMetadata.numberFormatMap === NumberFormat.perc) {
+      // NOTE: return average of percentages for percentage indicator. This is a temporary solution, as it should actually be weighed average. At least better than sum though.
       nrAlertAreasAndMainExposureValueSum.mainExposureValueSum =
         nrAlertAreasAndMainExposureValueSum.mainExposureValueSum /
         nrAlertAreasAndMainExposureValueSum.nrAlertAreas;

--- a/services/API-service/src/api/event/event.service.ts
+++ b/services/API-service/src/api/event/event.service.ts
@@ -598,7 +598,10 @@ export class EventService {
 
     areas.forEach((area) => {
       const eventName = area.eventName || 'unknown';
-      const currentHighest = eventAlertLevels[eventName] || AlertLevel.NONE;
+      if (!eventAlertLevels[eventName]) {
+        eventAlertLevels[eventName] = AlertLevel.NONE;
+      }
+      const currentHighest = eventAlertLevels[eventName];
 
       if (
         ALERT_LEVEL_RANK[area.alertLevel] > ALERT_LEVEL_RANK[currentHighest]

--- a/services/API-service/src/api/metadata/metadata.module.ts
+++ b/services/API-service/src/api/metadata/metadata.module.ts
@@ -4,7 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { HelperService } from '../../shared/helper.service';
 import { DisasterTypeEntity } from '../disaster-type/disaster-type.entity';
-import { EventModule } from '../event/event.module';
+import { DisasterTypeModule } from '../disaster-type/disaster-type.module';
 import { UserModule } from '../user/user.module';
 import { CountryModule } from './../country/country.module';
 import { IndicatorMetadataEntity } from './indicator-metadata.entity';
@@ -22,7 +22,7 @@ import { MetadataService } from './metadata.service';
       DisasterTypeEntity,
     ]),
     CountryModule,
-    EventModule,
+    DisasterTypeModule,
   ],
   providers: [MetadataService, HelperService],
   controllers: [MetadataController],

--- a/services/API-service/src/api/metadata/metadata.service.ts
+++ b/services/API-service/src/api/metadata/metadata.service.ts
@@ -21,7 +21,7 @@ export class MetadataService {
     private readonly disasterTypeService: DisasterTypeService,
   ) {}
 
-  public async getIndicatorMetadata(
+  public async getMainExposureIndicatorMetadata(
     disasterType: DisasterType,
   ): Promise<IndicatorMetadataEntity> {
     return await this.indicatorRepository.findOne({

--- a/services/API-service/src/api/metadata/metadata.service.ts
+++ b/services/API-service/src/api/metadata/metadata.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { DisasterType } from '../disaster-type/disaster-type.enum';
+import { DisasterTypeService } from '../disaster-type/disaster-type.service';
 import { AddIndicatorsDto, IndicatorDto } from './dto/add-indicators.dto';
 import { AddLayersDto, LayerDto } from './dto/add-layers.dto';
 import { IndicatorMetadataEntity } from './indicator-metadata.entity';
@@ -15,6 +16,21 @@ export class MetadataService {
   private readonly indicatorRepository: Repository<IndicatorMetadataEntity>;
   @InjectRepository(LayerMetadataEntity)
   private readonly layerRepository: Repository<LayerMetadataEntity>;
+
+  public constructor(
+    private readonly disasterTypeService: DisasterTypeService,
+  ) {}
+
+  public async getIndicatorMetadata(
+    disasterType: DisasterType,
+  ): Promise<IndicatorMetadataEntity> {
+    return await this.indicatorRepository.findOne({
+      where: {
+        name: (await this.disasterTypeService.getDisasterType(disasterType))
+          .mainExposureIndicator,
+      },
+    });
+  }
 
   public async addOrUpdateIndicators(
     indicators: AddIndicatorsDto,

--- a/services/API-service/src/api/metadata/metadata.service.ts
+++ b/services/API-service/src/api/metadata/metadata.service.ts
@@ -24,10 +24,11 @@ export class MetadataService {
   public async getMainExposureIndicatorMetadata(
     disasterType: DisasterType,
   ): Promise<IndicatorMetadataEntity> {
+    const mainExposureIndicator =
+      await this.disasterTypeService.getMainExposureIndicator(disasterType);
     return await this.indicatorRepository.findOne({
       where: {
-        name: (await this.disasterTypeService.getDisasterType(disasterType))
-          .mainExposureIndicator,
+        name: mainExposureIndicator,
       },
     });
   }

--- a/services/API-service/src/api/notification/dto/content-event-email.dto.ts
+++ b/services/API-service/src/api/notification/dto/content-event-email.dto.ts
@@ -7,7 +7,7 @@ import { NotificationDataPerEventDto } from './notification-date-per-event.dto';
 export class ContentEventEmail {
   public disasterType: DisasterType;
   public disasterTypeLabel: string;
-  public indicatorMetadata: IndicatorMetadataEntity;
+  public mainExposureIndicatorMetadata: IndicatorMetadataEntity;
   public linkEapSop: string;
   public dataPerEvent: NotificationDataPerEventDto[];
   public defaultAdminLevel: number;

--- a/services/API-service/src/api/notification/email/mjml/event-admin-area-table.ts
+++ b/services/API-service/src/api/notification/email/mjml/event-admin-area-table.ts
@@ -133,7 +133,7 @@ export const getMjmlAdminAreaTableList = (
         ),
         defaultAdminAreaLabel: emailContent.defaultAdminAreaLabel,
         defaultAdminAreaParentLabel: adminAreaParentLabel,
-        indicatorMetadata: emailContent.indicatorMetadata,
+        indicatorMetadata: emailContent.mainExposureIndicatorMetadata,
         event,
         triangleIcon: getTriangleIcon(
           event.eapAlertClass?.key,

--- a/services/API-service/src/api/notification/notification-content/notification-content.module.ts
+++ b/services/API-service/src/api/notification/notification-content/notification-content.module.ts
@@ -6,8 +6,10 @@ import { AdminAreaDataModule } from '../../admin-area-data/admin-area-data.modul
 import { AdminAreaModule } from '../../admin-area/admin-area.module';
 import { CountryEntity } from '../../country/country.entity';
 import { DisasterTypeEntity } from '../../disaster-type/disaster-type.entity';
+import { DisasterTypeModule } from '../../disaster-type/disaster-type.module';
 import { EventModule } from '../../event/event.module';
 import { IndicatorMetadataEntity } from '../../metadata/indicator-metadata.entity';
+import { MetadataModule } from '../../metadata/metadata.module';
 import { NotificationContentService } from './notification-content.service';
 
 @Module({
@@ -20,6 +22,8 @@ import { NotificationContentService } from './notification-content.service';
     EventModule,
     AdminAreaDataModule,
     AdminAreaModule,
+    DisasterTypeModule,
+    MetadataModule,
   ],
   controllers: [],
   providers: [NotificationContentService, HelperService],

--- a/services/API-service/src/api/notification/notification-content/notification-content.service.ts
+++ b/services/API-service/src/api/notification/notification-content/notification-content.service.ts
@@ -52,8 +52,8 @@ export class NotificationContentService {
     );
 
     content.country = country;
-    content.indicatorMetadata =
-      await this.metadataService.getIndicatorMetadata(disasterType);
+    content.mainExposureIndicatorMetadata =
+      await this.metadataService.getMainExposureIndicatorMetadata(disasterType);
     content.linkEapSop = this.getLinkEapSop(country, disasterType);
     content.defaultAdminAreaLabel = this.getDefaultAdminAreaLabel(
       country,
@@ -175,11 +175,11 @@ export class NotificationContentService {
       disasterType,
     );
 
-    const indicatorMetadata =
-      await this.metadataService.getIndicatorMetadata(disasterType);
+    const mainExposureIndicatorMetadata =
+      await this.metadataService.getMainExposureIndicatorMetadata(disasterType);
     data.totalAffectedOfIndicator = this.getTotal(
       data.alertAreas,
-      indicatorMetadata.numberFormatMap,
+      mainExposureIndicatorMetadata.numberFormatMap,
     );
     data.eapAlertClass = event.disasterSpecificProperties?.eapAlertClass;
     return data;

--- a/services/API-service/src/api/notification/whatsapp/whatsapp.module.ts
+++ b/services/API-service/src/api/notification/whatsapp/whatsapp.module.ts
@@ -10,6 +10,7 @@ import { API_PATHS } from '../../../config';
 import { HelperService } from '../../../shared/helper.service';
 import { CountryEntity } from '../../country/country.entity';
 import { EventModule } from '../../event/event.module';
+import { MetadataModule } from '../../metadata/metadata.module';
 import { UserEntity } from '../../user/user.entity';
 import { LookupModule } from '../lookup/lookup.module';
 import { NotificationContentModule } from '../notification-content/notification-content.module';
@@ -24,6 +25,7 @@ import { WhatsappService } from './whatsapp.service';
     LookupModule,
     EventModule,
     NotificationContentModule,
+    MetadataModule,
   ],
   providers: [WhatsappService, HelperService],
   controllers: [WhatsappController],

--- a/services/API-service/src/api/notification/whatsapp/whatsapp.service.ts
+++ b/services/API-service/src/api/notification/whatsapp/whatsapp.service.ts
@@ -359,15 +359,15 @@ export class WhatsappService {
 
     const adminAreaLabel =
       country.adminRegionLabels[String(adminLevel)]['plural'].toLowerCase();
-    const indicatorMetadata =
-      await this.metadataService.getIndicatorMetadata(disasterType);
+    const mainExposureIndicatorMetadata =
+      await this.metadataService.getMainExposureIndicatorMetadata(disasterType);
     let areaList = '';
     for (const area of alertAreas) {
       const row = `- *${area.name}${
         area.nameParent ? ' (' + area.nameParent + ')' : ''
       } - ${this.helperService.toCompactNumber(
         area.mainExposureValue,
-        indicatorMetadata.numberFormatMap,
+        mainExposureIndicatorMetadata.numberFormatMap,
       )}*\n`;
       areaList += row;
     }

--- a/services/API-service/src/api/notification/whatsapp/whatsapp.service.ts
+++ b/services/API-service/src/api/notification/whatsapp/whatsapp.service.ts
@@ -11,6 +11,7 @@ import { CountryEntity } from '../../country/country.entity';
 import { DisasterType } from '../../disaster-type/disaster-type.enum';
 import { AlertLevel } from '../../event/enum/alert-level.enum';
 import { EventService } from '../../event/event.service';
+import { MetadataService } from '../../metadata/metadata.service';
 import { UserEntity } from '../../user/user.entity';
 import { LookupService } from '../lookup/lookup.service';
 import { NotificationContentService } from '../notification-content/notification-content.service';
@@ -32,6 +33,7 @@ export class WhatsappService {
 
   public constructor(
     private readonly eventService: EventService,
+    private readonly metadataService: MetadataService,
     private readonly lookupService: LookupService,
     private readonly notificationContentService: NotificationContentService,
     private readonly helperService: HelperService,
@@ -358,7 +360,7 @@ export class WhatsappService {
     const adminAreaLabel =
       country.adminRegionLabels[String(adminLevel)]['plural'].toLowerCase();
     const indicatorMetadata =
-      await this.notificationContentService.getIndicatorMetadata(disasterType);
+      await this.metadataService.getIndicatorMetadata(disasterType);
     let areaList = '';
     for (const area of alertAreas) {
       const row = `- *${area.name}${

--- a/services/API-service/src/scripts/mock-helper.service.ts
+++ b/services/API-service/src/scripts/mock-helper.service.ts
@@ -126,18 +126,18 @@ export class MockHelperService {
       }
 
       // NOTE: this makes sure mock raster files are uploaded only once. If your intention is to have a different file, comment this out temporarily.
-      // const subfolder =
-      //   DisasterTypeGeoServerMapper.getSubfolderForDisasterType(disasterType);
-      // if (
-      //   fs.existsSync(
-      //     `./geoserver-volume/raster-files/output/${subfolder}/${destFileName}`,
-      //   )
-      // ) {
-      //   console.log(
-      //     `File ${destFileName} already exists in output folder. Skipping.`,
-      //   );
-      //   continue;
-      // }
+      const subfolder =
+        DisasterTypeGeoServerMapper.getSubfolderForDisasterType(disasterType);
+      if (
+        fs.existsSync(
+          `./geoserver-volume/raster-files/output/${subfolder}/${destFileName}`,
+        )
+      ) {
+        console.log(
+          `File ${destFileName} already exists in output folder. Skipping.`,
+        );
+        continue;
+      }
       // END NOTE
 
       let file;

--- a/services/API-service/src/shared/data.model.ts
+++ b/services/API-service/src/shared/data.model.ts
@@ -112,9 +112,6 @@ export class EventSummaryCountry {
   @ApiProperty({ example: 100 })
   public forecastSeverity: number;
 
-  @ApiProperty({ example: 5 })
-  public nrAlertAreas: number;
-
   @ApiProperty({ example: AlertLevel.NONE })
   public alertLevel: AlertLevel;
 
@@ -123,4 +120,7 @@ export class EventSummaryCountry {
 
   @ApiProperty({ example: 'Henry Dunant' })
   public userTriggerName: string;
+
+  @ApiProperty({ example: [] })
+  public alertAreas?: AlertArea[];
 }

--- a/tests/integration/helpers/utility.helper.ts
+++ b/tests/integration/helpers/utility.helper.ts
@@ -181,17 +181,6 @@ export function postEventsProcess(
     .send(eventsProcessDto);
 }
 
-export function getAlertAreas(
-  countryCodeISO3: string,
-  adminLevel: number,
-  disasterType: DisasterType,
-  accessToken: string,
-): Promise<request.Response> {
-  return getServer()
-    .get(`/event/alert-areas/${countryCodeISO3}/${adminLevel}/${disasterType}`)
-    .set('Authorization', `Bearer ${accessToken}`);
-}
-
 export function postSetTrigger(
   eventPlaceCodeIds: string[],
   accessToken: string,


### PR DESCRIPTION
## Describe your changes

I’m stuck on the aggregates and admin area data (static and dynamic).

The dead-ends I hit,
- [getEventAreaAggregatesPerIndicator](https://github.com/rodekruis/IBF-system/blob/2a29517b2e98b05a10e570dd1074ef3de4b5c1ad/services/API-service/src/api/admin-area/services/event-area.service.ts#L215)
- [getEventAreaDynamicData](https://github.com/rodekruis/IBF-system/blob/2a29517b2e98b05a10e570dd1074ef3de4b5c1ad/services/API-service/src/api/admin-area/services/event-area.service.ts#L173)
- [getEventAreas](https://github.com/rodekruis/IBF-system/blob/2a29517b2e98b05a10e570dd1074ef3de4b5c1ad/services/API-service/src/api/admin-area/services/event-area.service.ts#L76)
- [getEventAreaAggregates](https://github.com/rodekruis/IBF-system/blob/2a29517b2e98b05a10e570dd1074ef3de4b5c1ad/services/API-service/src/api/admin-area/services/event-area.service.ts#L144)

For Malawi flash-floods, I tried to filter areas based on highest alert level but it changes the behaviour significantly because event areas mean something else.

@jannisvisser any ideas on how to proceed?