### PR TITLE
refactor: calculate event aggregates in front-end AB#34119

### DIFF
--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.ts
@@ -76,11 +76,29 @@ export class EventSpeechBubbleComponent implements AfterViewChecked, OnDestroy {
 
     if (this.event) {
       this.event.header = this.getHeader(this.event);
+      this.event.mainExposureValueSum = this.getEventMainExposureValue(
+        this.event,
+        this.mainExposureIndicatorNumberFormat,
+      );
     }
   }
 
   ngOnDestroy() {
     this.placeCodeHoverSubscription.unsubscribe();
+  }
+
+  private getEventMainExposureValue(
+    event: EventSummary,
+    mainExposureIndicatorNumberFormat: NumberFormat,
+  ) {
+    const sum = event.alertAreas.reduce(
+      (acc, alertArea) => acc + alertArea.mainExposureValue,
+      0,
+    );
+    if (mainExposureIndicatorNumberFormat === NumberFormat.perc) {
+      return sum / event.alertAreas.length;
+    }
+    return sum;
   }
 
   public selectArea(area: AlertArea) {

--- a/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/event-speech-bubble/event-speech-bubble.component.ts
@@ -91,12 +91,13 @@ export class EventSpeechBubbleComponent implements AfterViewChecked, OnDestroy {
     event: EventSummary,
     mainExposureIndicatorNumberFormat: NumberFormat,
   ) {
-    const sum = event.alertAreas.reduce(
+    const sum = event.alertAreas?.reduce(
       (acc, alertArea) => acc + alertArea.mainExposureValue,
       0,
     );
+    // NOTE: this is a temporary solution, as this actually needs a weighted average. At least this is better than sum.
     if (mainExposureIndicatorNumberFormat === NumberFormat.perc) {
-      return sum / event.alertAreas.length;
+      return sum / event.alertAreas?.length || 1;
     }
     return sum;
   }

--- a/interfaces/IBF-dashboard/src/app/mocks/event-state.mock.ts
+++ b/interfaces/IBF-dashboard/src/app/mocks/event-state.mock.ts
@@ -1,3 +1,4 @@
+import { MOCK_ALERT_AREAS } from 'src/app/mocks/alert-areas.mock';
 import { AlertLevel, EventSummary } from 'src/app/services/event.service';
 import { EventState } from 'src/app/types/event-state';
 
@@ -12,6 +13,7 @@ const MOCK_EVENT: EventSummary = {
   userTrigger: false,
   userTriggerDate: null,
   userTriggerName: null,
+  alertAreas: MOCK_ALERT_AREAS,
 };
 export const MOCK_EVENT_STATE: EventState = {
   events: [MOCK_EVENT, MOCK_EVENT],

--- a/interfaces/IBF-dashboard/src/app/services/alert-area.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/alert-area.service.ts
@@ -117,20 +117,17 @@ export class AlertAreaService {
       this.timelineState &&
       this.eventState
     ) {
-      // This makes sure that if placeCode is set, that adminLevel is used below (which affects e.g. the chat-section) ..
-      // .. which is 1 adminLevel highr than the one used in the map ..
-      // .. if not set yet (so on highest adminLevel), then the chat-section uses the same level as the map (namely the defaultAdminLevel)
-      const adminLevelToUse =
-        this.placeCode?.adminLevel ||
-        this.countryDisasterSettings.defaultAdminLevel;
-      this.apiService
-        .getAlertAreas(
-          this.country.countryCodeISO3,
-          this.disasterType.disasterType,
-          adminLevelToUse,
-          this.eventState.event?.eventName,
-        )
-        .subscribe(this.onAlertAreas);
+      if (this.eventState?.event) {
+        this.onAlertAreas(this.eventState.event.alertAreas);
+      } else if (this.eventState?.events.length) {
+        // Multiple events case - concatenate all alertAreas arrays
+        const allAlertAreas = this.eventState.events.flatMap(
+          (event) => event.alertAreas || [],
+        );
+        this.onAlertAreas(allAlertAreas);
+      } else {
+        this.onAlertAreas([]);
+      }
     }
   }
 

--- a/interfaces/IBF-dashboard/src/app/services/alert-area.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/alert-area.service.ts
@@ -98,19 +98,19 @@ export class AlertAreaService {
         this.placeCode,
       );
       if (adminLevelType !== AdminLevelType.higher) {
-        this.getAlertAreasApi();
+        this.loadAlertAreas();
       }
     } else {
-      this.getAlertAreasApi();
+      this.loadAlertAreas();
     }
   };
 
   private onPlaceCodeChange = (placeCode: PlaceCode) => {
     this.placeCode = placeCode;
-    this.getAlertAreasApi();
+    this.loadAlertAreas();
   };
 
-  private getAlertAreasApi() {
+  private loadAlertAreas() {
     if (
       this.country &&
       this.disasterType &&
@@ -118,20 +118,20 @@ export class AlertAreaService {
       this.eventState
     ) {
       if (this.eventState?.event) {
-        this.onAlertAreas(this.eventState.event.alertAreas);
+        this.processAlertAreas(this.eventState.event.alertAreas);
       } else if (this.eventState?.events.length) {
         // Multiple events case - concatenate all alertAreas arrays
         const allAlertAreas = this.eventState.events.flatMap(
           (event) => event.alertAreas || [],
         );
-        this.onAlertAreas(allAlertAreas);
+        this.processAlertAreas(allAlertAreas);
       } else {
-        this.onAlertAreas([]);
+        this.processAlertAreas([]);
       }
     }
   }
 
-  private onAlertAreas = (alertAreas: AlertArea[]) => {
+  private processAlertAreas = (alertAreas: AlertArea[]) => {
     this.alertAreas = alertAreas;
     this.alertAreas.sort((a, b) => {
       if (a.forecastSeverity === b.forecastSeverity) {
@@ -167,6 +167,7 @@ export class AlertAreaService {
         });
       });
     }
+    // REFACTOR: there is no longer need for a subscription here, as this data is not retrieved from API here, but already earlier known. Clean up the subscription chain.
     this.alertAreaSubject.next(this.alertAreas);
   };
 

--- a/interfaces/IBF-dashboard/src/app/services/api.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/api.service.ts
@@ -11,7 +11,6 @@ import { EventSummary } from 'src/app/services/event.service';
 import { JwtService } from 'src/app/services/jwt.service';
 import { AdminLevel } from 'src/app/types/admin-level';
 import { AggregateRecord } from 'src/app/types/aggregate';
-import { AlertArea } from 'src/app/types/alert-area';
 import { DisasterTypeKey } from 'src/app/types/disaster-type-key';
 import { IbfLayerMetadata, IbfLayerName } from 'src/app/types/ibf-layer';
 import { Indicator } from 'src/app/types/indicator-group';
@@ -271,23 +270,6 @@ export class ApiService {
     }
     return this.get(
       `admin-areas/aggregates/${countryCodeISO3}/${disasterType}/${adminLevel.toString()}`,
-      false,
-      params,
-    );
-  }
-
-  getAlertAreas(
-    countryCodeISO3: string,
-    disasterType: DisasterTypeKey,
-    adminLevel: number,
-    eventName: string,
-  ): Observable<AlertArea[]> {
-    let params = new HttpParams();
-    if (eventName) {
-      params = params.append('eventName', eventName);
-    }
-    return this.get(
-      `event/alert-areas/${countryCodeISO3}/${adminLevel.toString()}/${disasterType}`,
       false,
       params,
     );

--- a/interfaces/IBF-dashboard/src/app/services/event.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/event.service.ts
@@ -15,6 +15,7 @@ import {
 import { ApiService } from 'src/app/services/api.service';
 import { CountryService } from 'src/app/services/country.service';
 import { DisasterTypeService } from 'src/app/services/disaster-type.service';
+import { AlertArea } from 'src/app/types/alert-area';
 import { DisasterTypeKey } from 'src/app/types/disaster-type-key';
 import { EventState } from 'src/app/types/event-state';
 import { LastUploadDate } from 'src/app/types/last-upload-date';
@@ -39,6 +40,7 @@ export class EventSummary {
   duration?: number;
   disasterSpecificProperties: DisasterSpecificProperties;
   header?: string;
+  alertAreas?: AlertArea[];
   nrAlertAreas?: number;
   mainExposureValueSum?: number;
   alertLevel: AlertLevel;
@@ -240,6 +242,7 @@ export class EventService {
           : null;
 
         event.duration = this.getEventDuration(event);
+        event.nrAlertAreas = event.alertAreas?.length;
       }
     }
 

--- a/services/API-service/src/api/event/event.controller.ts
+++ b/services/API-service/src/api/event/event.controller.ts
@@ -20,7 +20,7 @@ import { UpdateResult } from 'typeorm';
 
 import { Roles } from '../../roles.decorator';
 import { RolesGuard } from '../../roles.guard';
-import { AlertArea, EventSummaryCountry } from '../../shared/data.model';
+import { EventSummaryCountry } from '../../shared/data.model';
 import { DisasterType } from '../disaster-type/disaster-type.enum';
 import { UserRole } from '../user/user-role.enum';
 import { UserDecorator } from '../user/user.decorator';
@@ -110,34 +110,6 @@ export class EventController {
     return await this.eventService.getAlertPerLeadTime(
       params.countryCodeISO3,
       params.disasterType,
-      query.eventName,
-    );
-  }
-
-  @UseGuards(RolesGuard)
-  @ApiOperation({
-    summary:
-      'Get alerted admin-areas for given country, disaster-type, admin-level (and event-name).',
-  })
-  @ApiParam({ name: 'countryCodeISO3', required: true, type: 'string' })
-  @ApiParam({ name: 'disasterType', required: true, enum: DisasterType })
-  @ApiParam({ name: 'adminLevel', required: true, type: 'number' })
-  @ApiQuery({ name: 'eventName', required: false, type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description:
-      'Alerted admin-areas for given country, disaster-type, admin-level (and event-name).',
-    type: [AlertArea],
-  })
-  @Get('alert-areas/:countryCodeISO3/:adminLevel/:disasterType')
-  public async getAlertAreas(
-    @Param() params,
-    @Query() query,
-  ): Promise<AlertArea[]> {
-    return await this.eventService.getAlertAreas(
-      params.countryCodeISO3,
-      params.disasterType,
-      params.adminLevel,
       query.eventName,
     );
   }

--- a/services/API-service/src/shared/data.model.ts
+++ b/services/API-service/src/shared/data.model.ts
@@ -112,9 +112,6 @@ export class EventSummaryCountry {
   @ApiProperty({ example: 100 })
   public forecastSeverity: number;
 
-  @ApiProperty({ example: 5 })
-  public nrAlertAreas: number;
-
   @ApiProperty({ example: AlertLevel.NONE })
   public alertLevel: AlertLevel;
 
@@ -123,4 +120,7 @@ export class EventSummaryCountry {
 
   @ApiProperty({ example: 'Henry Dunant' })
   public userTriggerName: string;
+
+  @ApiProperty({ example: [] })
+  public alertAreas?: AlertArea[];
 }

--- a/tests/integration/helpers/utility.helper.ts
+++ b/tests/integration/helpers/utility.helper.ts
@@ -181,17 +181,6 @@ export function postEventsProcess(
     .send(eventsProcessDto);
 }
 
-export function getAlertAreas(
-  countryCodeISO3: string,
-  adminLevel: number,
-  disasterType: DisasterType,
-  accessToken: string,
-): Promise<request.Response> {
-  return getServer()
-    .get(`/event/alert-areas/${countryCodeISO3}/${adminLevel}/${disasterType}`)
-    .set('Authorization', `Bearer ${accessToken}`);
-}
-
 export function postSetTrigger(
   eventPlaceCodeIds: string[],
   accessToken: string,


### PR DESCRIPTION
## Describe your changes

- Rough idea for moving the event-aggregates calculation to the front-end as discussed. 
- By making GET /alert-areas content a part of GET /event.
- This is not fully ready, as - if agreed - it needs some more cleaning up. Especially in the alert-area.service, as there is not really a reason to add a subscription to AlertAreas any more, if this data is already available earlier in eventState.
- to do also: fix integration test
- tied this to separate task [AB#34525](https://dev.azure.com/redcrossnl/9e7ca3cc-bb97-4471-a25c-fd9787af0fe8/_workitems/edit/34525)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review

