### PR TITLE
feat: show different advisory for set-trigger warning in email

### DIFF
--- a/services/API-service/src/api/notification/dto/content-event-email.dto.ts
+++ b/services/API-service/src/api/notification/dto/content-event-email.dto.ts
@@ -1,12 +1,11 @@
 import { CountryEntity } from '../../country/country.entity';
-import { DisasterType } from '../../disaster-type/disaster-type.enum';
+import { DisasterTypeEntity } from '../../disaster-type/disaster-type.entity';
 import { IndicatorMetadataEntity } from '../../metadata/indicator-metadata.entity';
 import { AdminAreaLabel } from './admin-area-notification-info.dto';
 import { NotificationDataPerEventDto } from './notification-date-per-event.dto';
 
 export class ContentEventEmail {
-  public disasterType: DisasterType;
-  public disasterTypeLabel: string;
+  public disasterType: DisasterTypeEntity;
   public mainExposureIndicatorMetadata: IndicatorMetadataEntity;
   public linkEapSop: string;
   public dataPerEvent: NotificationDataPerEventDto[];

--- a/services/API-service/src/api/notification/email/email.service.ts
+++ b/services/API-service/src/api/notification/email/email.service.ts
@@ -70,7 +70,7 @@ export class EmailService {
       // );
       return emailHtml;
     }
-    let emailSubject = `IBF ${emailContent.disasterTypeLabel} alert`;
+    let emailSubject = `IBF ${emailContent.disasterType.disasterType} alert`;
     if (process.env.NODE_ENV !== 'production') {
       emailSubject += ` - ${process.env.NODE_ENV.toUpperCase()}`;
     }

--- a/services/API-service/src/api/notification/email/mjml.service.ts
+++ b/services/API-service/src/api/notification/email/mjml.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import mjml2html from 'mjml';
 
 import { HelperService } from '../../../shared/helper.service';
+import { firstCharOfWordsToUpper } from '../../../shared/utils';
 import { ContentEventEmail } from '../dto/content-event-email.dto';
 import {
   BODY_WIDTH,
@@ -40,11 +41,15 @@ export class MjmlService {
     date: Date;
   }) =>
     getMjmlHeader({
-      disasterTypeLabel: emailContent.disasterTypeLabel,
+      disasterTypeLabel: firstCharOfWordsToUpper(
+        emailContent.disasterType.label,
+      ),
       nrOfEvents: emailContent.dataPerEvent.length,
       sentOnDate: getFormattedDate({ date }),
       logosSrc:
-        emailContent.country.notificationInfo.logo[emailContent.disasterType],
+        emailContent.country.notificationInfo.logo[
+          emailContent.disasterType.disasterType
+        ],
     });
 
   private footer = ({ countryName }: { countryName: string }) => [
@@ -100,7 +105,7 @@ export class MjmlService {
       getMjmlTriggerStatement({
         triggerStatement:
           emailContent.country.notificationInfo.triggerStatement[
-            emailContent.disasterType
+            emailContent.disasterType.disasterType
           ],
       }),
     );
@@ -148,7 +153,7 @@ export class MjmlService {
 
     children.push(
       ...getMjmlFinishedEvents({
-        disasterType: emailContent.disasterTypeLabel,
+        disasterType: emailContent.disasterType.disasterType,
         dataPerEvent: emailContent.dataPerEvent,
         timezone: getTimezoneDisplay(emailContent.country.countryCodeISO3),
       }),

--- a/services/API-service/src/api/notification/email/mjml/body-event.ts
+++ b/services/API-service/src/api/notification/email/mjml/body-event.ts
@@ -119,7 +119,7 @@ const getMjmlBodyEvent = ({
         ? `<strong>Advisory:</strong> Activate <a href="${eapLink}">Protocol</a>` // Not all implemtations have an EAP, so for now defaulting to more generic copy
         : `<strong>Advisory:</strong> Activate Protocol`
       : enableSetWarningToTrigger
-        ? `An IBF focal point user can set this warning as a trigger${forecastSource?.setTriggerSource ? ` based on ${forecastSource.setTriggerSource}` : ''}.`
+        ? `<strong>Advisory:</strong> An IBF focal point user can set this warning as a trigger${forecastSource?.setTriggerSource ? ` based on ${forecastSource.setTriggerSource}` : ''}.`
         : `<strong>Advisory:</strong> Inform all potentialy exposed ${defaultAdminAreaLabel}`,
   );
 

--- a/services/API-service/src/api/notification/email/mjml/event-admin-area-table.ts
+++ b/services/API-service/src/api/notification/email/mjml/event-admin-area-table.ts
@@ -1,4 +1,5 @@
 import { NumberFormat } from '../../../../shared/enums/number-format.enum';
+import { firstCharOfWordsToUpper } from '../../../../shared/utils';
 import { IndicatorMetadataEntity } from '../../../metadata/indicator-metadata.entity';
 import { AdminAreaLabel } from '../../dto/admin-area-notification-info.dto';
 import { ContentEventEmail } from '../../dto/content-event-email.dto';
@@ -126,7 +127,9 @@ export const getMjmlAdminAreaTableList = (
   for (const event of emailContent.dataPerEvent) {
     adminAreaTableList.push(
       getMjmlEventAdminAreaTable({
-        disasterTypeLabel: emailContent.disasterTypeLabel,
+        disasterTypeLabel: firstCharOfWordsToUpper(
+          emailContent.disasterType.label,
+        ),
         textColour: getIbfHexColor(
           event.eapAlertClass?.color,
           event.triggerStatusLabel,

--- a/services/API-service/src/api/notification/notification-content/notification-content.service.ts
+++ b/services/API-service/src/api/notification/notification-content/notification-content.service.ts
@@ -6,6 +6,7 @@ import { Repository } from 'typeorm';
 import { AlertArea, EventSummaryCountry } from '../../../shared/data.model';
 import { NumberFormat } from '../../../shared/enums/number-format.enum';
 import { HelperService } from '../../../shared/helper.service';
+import { firstCharOfWordsToUpper } from '../../../shared/utils';
 import { LeadTime } from '../../admin-area-dynamic-data/enum/lead-time.enum';
 import { CountryEntity } from '../../country/country.entity';
 import { DisasterType } from '../../disaster-type/disaster-type.enum';
@@ -39,8 +40,8 @@ export class NotificationContentService {
     activeEvents: EventSummaryCountry[],
   ): Promise<ContentEventEmail> {
     const content = new ContentEventEmail();
-    content.disasterType = disasterType;
-    content.disasterTypeLabel = await this.getDisasterTypeLabel(disasterType);
+    content.disasterType =
+      await this.disasterTypeService.getDisasterType(disasterType);
     content.dataPerEvent = await this.getNotificationDataForEvents(
       activeEvents,
       country,
@@ -103,14 +104,6 @@ export class NotificationContentService {
     adminAreaDefaultLevel: number,
   ): AdminAreaLabel {
     return country.adminRegionLabels[String(adminAreaDefaultLevel)];
-  }
-
-  private firstCharOfWordsToUpper(input: string): string {
-    return input
-      .toLowerCase()
-      .split(' ')
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
   }
 
   public async getFormattedEventName(
@@ -332,7 +325,7 @@ export class NotificationContentService {
   }
 
   public async getDisasterTypeLabel(disasterType: DisasterType) {
-    return this.firstCharOfWordsToUpper(
+    return firstCharOfWordsToUpper(
       (await this.disasterTypeService.getDisasterType(disasterType)).label,
     );
   }

--- a/services/API-service/src/shared/utils.ts
+++ b/services/API-service/src/shared/utils.ts
@@ -1,0 +1,7 @@
+export const firstCharOfWordsToUpper = (input: string) => {
+  return input
+    .toLowerCase()
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};


### PR DESCRIPTION
## Describe your changes

Show different advisory in warning email that can be set to trigger. See [AB#34603](https://dev.azure.com/redcrossnl/9e7ca3cc-bb97-4471-a25c-fd9787af0fe8/_workitems/edit/34603).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review

