### PR TITLE
fix: only join event data of correct disaster-type AB#34736

### DIFF
--- a/services/API-service/src/api/admin-area/admin-area.service.ts
+++ b/services/API-service/src/api/admin-area/admin-area.service.ts
@@ -399,7 +399,6 @@ export class AdminAreaService {
     }
 
     let adminAreas = await adminAreasScript.getRawMany();
-    console.log('adminAreasScript: ', adminAreasScript.getQueryAndParameters());
     adminAreas.forEach((area) => {
       area.alertLevel = this.eventService.getAlertLevel(area);
     });

--- a/services/API-service/src/api/admin-area/admin-area.service.ts
+++ b/services/API-service/src/api/admin-area/admin-area.service.ts
@@ -223,7 +223,8 @@ export class AdminAreaService {
       .leftJoin(
         EventPlaceCodeEntity,
         'epc',
-        'area.id = epc.adminAreaId AND epc.closed = false',
+        'area.id = epc.adminAreaId AND epc.closed = false AND epc."disasterType" = :disasterType',
+        { disasterType },
       )
       .addSelect([
         'epc."forecastSeverity"',
@@ -328,7 +329,8 @@ export class AdminAreaService {
       .leftJoin(
         EventPlaceCodeEntity,
         'epc',
-        'area.id = epc.adminAreaId AND epc.closed = false',
+        'area.id = epc.adminAreaId AND epc.closed = false AND epc."disasterType" = :disasterType',
+        { disasterType },
       )
       .addSelect([
         'epc."forecastSeverity"',
@@ -397,6 +399,7 @@ export class AdminAreaService {
     }
 
     let adminAreas = await adminAreasScript.getRawMany();
+    console.log('adminAreasScript: ', adminAreasScript.getQueryAndParameters());
     adminAreas.forEach((area) => {
       area.alertLevel = this.eventService.getAlertLevel(area);
     });


### PR DESCRIPTION
## Describe your changes

Don't join events of wrong disaster type to admin-areas.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review

