### PR TITLE
build: seed init with truncate

### DIFF
--- a/services/API-service/package.json
+++ b/services/API-service/package.json
@@ -9,7 +9,7 @@
     "lint:syntax": "prettier --check \"**/*.{md,js,ts,scss,html}\" ",
     "prestart": "npm run migration:run && ts-node src/scripts seed-prod",
     "start": "node index.js",
-    "prestart:dev": "npm run migration:run && ts-node src/scripts seed-prod && ts-node src/scripts seed-init",
+    "prestart:dev": "npm run migration:run && ts-node src/scripts seed-init",
     "start:dev": "npx tsc-watch --onSuccess \"  node index.js  \" --onFailure \"echo There was a problem with the build!\" -p tsconfig.json",
     "prestart:prod": "tsc",
     "start:prod": "node dist/main.js",

--- a/services/API-service/src/api/user/dto/create-user.dto.ts
+++ b/services/API-service/src/api/user/dto/create-user.dto.ts
@@ -11,6 +11,7 @@ import {
   MinLength,
 } from 'class-validator';
 
+import { DUNANT_EMAIL } from '../../../config';
 import countries from '../../../scripts/json/countries.json';
 import disasterTypes from '../../../scripts/json/disaster-types.json';
 import { UserRole } from '../user-role.enum';
@@ -20,7 +21,7 @@ export const userRoleArray = Object.values(UserRole).map((item) =>
 );
 
 export class CreateUserDto {
-  @ApiProperty({ example: 'dunant@redcross.nl' })
+  @ApiProperty({ example: DUNANT_EMAIL })
   @IsEmail()
   @IsNotEmpty()
   public email: string;

--- a/services/API-service/src/api/user/dto/login-user.dto.ts
+++ b/services/API-service/src/api/user/dto/login-user.dto.ts
@@ -2,8 +2,10 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
 
+import { DUNANT_EMAIL } from '../../../config';
+
 export class LoginUserDto {
-  @ApiProperty({ example: 'dunant@redcross.nl' })
+  @ApiProperty({ example: DUNANT_EMAIL })
   @IsEmail()
   @IsNotEmpty()
   public email: string;

--- a/services/API-service/src/api/user/user.model.ts
+++ b/services/API-service/src/api/user/user.model.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+import { DUNANT_EMAIL } from '../../config';
 import { UserRole } from './user-role.enum';
 
 export class User {
@@ -16,7 +17,7 @@ export class User {
 }
 
 export class UserData {
-  @ApiProperty({ example: 'dunant@redcross.nl' })
+  @ApiProperty({ example: DUNANT_EMAIL })
   public email: string;
 
   @ApiProperty({ example: 'Henry' })

--- a/services/API-service/src/config.ts
+++ b/services/API-service/src/config.ts
@@ -1,6 +1,7 @@
 export const DEBUG =
   ['production', 'test', 'ci'].indexOf(process.env.NODE_ENV) < 0; // true if NODE_ENV is not in list
 export const PORT = 3000;
+export const DUNANT_EMAIL = 'dunant@redcross.nl';
 
 // Configure Internal and External API URL's
 // ---------------------------------------------------------------------------

--- a/services/API-service/src/scripts/scripts.controller.ts
+++ b/services/API-service/src/scripts/scripts.controller.ts
@@ -59,7 +59,7 @@ export class ScriptsController {
       return res.status(HttpStatus.FORBIDDEN).send('Not allowed');
     }
 
-    await this.seedInit.run(null, includeLinesData);
+    await this.seedInit.run(null, includeLinesData, true);
     return res
       .status(HttpStatus.ACCEPTED)
       .send('Database reset with original seed data.');

--- a/services/API-service/src/scripts/seed-helper.ts
+++ b/services/API-service/src/scripts/seed-helper.ts
@@ -3,6 +3,8 @@ import fs from 'fs';
 import { Readable } from 'stream';
 import { DataSource } from 'typeorm';
 
+import { DUNANT_EMAIL } from '../config';
+
 export class SeedHelper {
   public constructor(private dataSource: DataSource) {}
 
@@ -47,7 +49,7 @@ export class SeedHelper {
         ) {
           let q;
           if (entity.tableName === 'user') {
-            q = `DELETE FROM \"${repository.metadata.schema}\".\"${entity.tableName}\" WHERE email <> 'dunant@redcross.nl'`;
+            q = `DELETE FROM \"${repository.metadata.schema}\".\"${entity.tableName}\" WHERE email <> '${DUNANT_EMAIL}';`;
           } else {
             q = `TRUNCATE TABLE \"${repository.metadata.schema}\".\"${entity.tableName}\" CASCADE;`;
           }

--- a/services/API-service/src/scripts/seed-init.ts
+++ b/services/API-service/src/scripts/seed-init.ts
@@ -19,6 +19,7 @@ import { LayerMetadataEntity } from '../api/metadata/layer-metadata.entity';
 import { NotificationInfoEntity } from '../api/notification/notifcation-info.entity';
 import { UserEntity } from '../api/user/user.entity';
 import { UserRole } from '../api/user/user-role.enum';
+import { DUNANT_EMAIL } from '../config';
 import countries from './json/countries.json';
 import disasterTypes from './json/disaster-types.json';
 import eapActions from './json/EAP-actions.json';
@@ -55,9 +56,8 @@ export class SeedInit implements InterfaceScript {
     truncate: boolean = false,
   ): Promise<void> {
     const userRepository = this.dataSource.getRepository(UserEntity);
-    const dunantEmail = 'dunant@redcross.nl';
     const dunantUser = await userRepository.findOne({
-      where: { email: dunantEmail },
+      where: { email: DUNANT_EMAIL },
     });
 
     if (truncate) {
@@ -143,7 +143,7 @@ export class SeedInit implements InterfaceScript {
       selectedUsers[0].password = process.env.ADMIN_PASSWORD;
     } else {
       if (dunantUser) {
-        selectedUsers = users.filter((user) => user.email !== dunantEmail);
+        selectedUsers = users.filter((user) => user.email !== DUNANT_EMAIL);
         dunantUser.countries = await countryRepository.find();
         await userRepository.save(dunantUser);
       } else {

--- a/services/API-service/src/scripts/seed-prod.ts
+++ b/services/API-service/src/scripts/seed-prod.ts
@@ -14,7 +14,7 @@ export class SeedProd implements InterfaceScript {
   public constructor(private dataSource: DataSource) {}
 
   public async run(): Promise<void> {
-    this.logger.log('Seeding production data...');
+    this.logger.log('Seed admin user...');
     const userRepository = this.dataSource.getRepository(UserEntity);
     if ((await userRepository.find({ take: 1 })).length === 0) {
       const user = users.filter((user): boolean => {
@@ -33,9 +33,7 @@ export class SeedProd implements InterfaceScript {
 
       await userRepository.save(adminUser);
     } else {
-      this.logger.log(
-        '----------------NOTE: Users were found in database already, so admin-user not added------------------',
-      );
+      this.logger.log('Users already exist, skip seed admin user.');
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

This PR is a follow-up on https://github.com/rodekruis/IBF-system/pull/2168

It includes,
- Add truncate flag to seed init
    - needed for `/api/scripts/reset`
    - this allows running seed init without seed prod in `prestart:dev`
- Use clearer log message in seed prod.
    - _Seeding production data..._ implied more than what it was doing _Seed admin user..._
- Move dunant email to the config file
    - minor refactor so that we don't have to file search through the repo to find its usage

Seed init is an alternative to seed prod. Either is called only once when the database is empty. They are separate because seed init is reused for `/api/scripts/reset`

If my implementation works, we don't have to reset manually each time we load up a new IBF instance. This is mostly for dev, but it happens often, so the effort is justified.
#### When not in production,
- If the database is empty, seed init _seeds_ the database.
- If the database is not empty, seed init is skipped.
- If reset is called, the database is emptied, followed by a seed init.
#### When in production,
- If the database is empty, seed prod _seeds_ the admin user.
    - The dev can use this admin user to reset the database.
- If the database is not empty, seed prod is skipped. The database should not be empty.
- reset should not be called in production. This is protected with a RESET_SECRET.