### PR TITLE
fix: event place code and eap action status foreign key delete cascade

### DIFF
--- a/services/API-service/migration/1747049702168-EapActonStatusEventPlaceCodeDeleteCascade.ts
+++ b/services/API-service/migration/1747049702168-EapActonStatusEventPlaceCodeDeleteCascade.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class EapActonStatusEventPlaceCodeDeleteCascade1747049702168
+  implements MigrationInterface
+{
+  name = 'EapActonStatusEventPlaceCodeDeleteCascade1747049702168';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "IBF-app"."eap-action-status" DROP CONSTRAINT "FK_7542139f48d6fb143dc38afa81f"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IBF-app"."eap-action-status" ADD CONSTRAINT "FK_7542139f48d6fb143dc38afa81f" FOREIGN KEY ("eventPlaceCodeEventPlaceCodeId") REFERENCES "IBF-app"."event-place-code"("eventPlaceCodeId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "IBF-app"."eap-action-status" DROP CONSTRAINT "FK_7542139f48d6fb143dc38afa81f"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IBF-app"."eap-action-status" ADD CONSTRAINT "FK_7542139f48d6fb143dc38afa81f" FOREIGN KEY ("eventPlaceCodeEventPlaceCodeId") REFERENCES "IBF-app"."event-place-code"("eventPlaceCodeId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/services/API-service/src/api/eap-actions/eap-action-status.entity.ts
+++ b/services/API-service/src/api/eap-actions/eap-action-status.entity.ts
@@ -34,6 +34,7 @@ export class EapActionStatusEntity {
     (): typeof EventPlaceCodeEntity => EventPlaceCodeEntity,
     (eventPlaceCode): EapActionStatusEntity[] =>
       eventPlaceCode.eapActionStatuses,
+    { onDelete: 'CASCADE' },
   )
   public eventPlaceCode: EventPlaceCodeEntity;
 

--- a/services/API-service/src/api/event/event-place-code.entity.ts
+++ b/services/API-service/src/api/event/event-place-code.entity.ts
@@ -61,7 +61,7 @@ export class EventPlaceCodeEntity {
   @OneToMany(
     (): typeof EapActionStatusEntity => EapActionStatusEntity,
     (eapActionStatus): EventPlaceCodeEntity => eapActionStatus.eventPlaceCode,
-    { onDelete: 'CASCADE' },
+    { cascade: true },
   )
   @JoinTable()
   public eapActionStatuses: EapActionStatusEntity[];


### PR DESCRIPTION
## Describe your changes

This PR defines a DELETE CASCADE between event-place-code and eap-action-status. This was needed to update Uganda admin level 2 and admin level 3. See [AB#35112](https://dev.azure.com/redcrossnl/IBF/_workitems/edit/35112) for details.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review

