### PR TITLE
refactor: allow admin area update

### DIFF
--- a/services/API-service/src/api/admin-area-data/dto/admin-area-data.dto.ts
+++ b/services/API-service/src/api/admin-area-data/dto/admin-area-data.dto.ts
@@ -13,6 +13,7 @@ import {
 import { JoinColumn, ManyToOne } from 'typeorm';
 
 import indicatorData from '../../../scripts/mock-data/drought/ETH/trigger/Belg JAS_Belg/upload-forecast_trigger-2.json';
+import { AdminAreaParams } from '../../admin-area/dto/admin-area.dto';
 import { DynamicDataPlaceCodeDto } from '../../admin-area-dynamic-data/dto/dynamic-data-place-code.dto';
 import { StaticIndicator } from '../../admin-area-dynamic-data/enum/dynamic-indicator.enum';
 import { AdminLevel } from '../../country/admin-level.enum';
@@ -74,8 +75,6 @@ export class AdminAreaDataJsonDto {
   public dataPlaceCode: DynamicDataPlaceCodeDto[];
 }
 
-export interface AdminAreaDataParams {
-  countryCodeISO3: string;
-  adminLevel: AdminLevel;
+export interface AdminAreaDataParams extends AdminAreaParams {
   indicator: StaticIndicator;
 }

--- a/services/API-service/src/api/admin-area/admin-area.controller.ts
+++ b/services/API-service/src/api/admin-area/admin-area.controller.ts
@@ -22,11 +22,11 @@ import {
 } from '@nestjs/swagger';
 
 import { Response } from 'express';
+import { FeatureCollection } from 'typeorm';
 
 import { Roles } from '../../roles.decorator';
 import { RolesGuard } from '../../roles.guard';
 import { AggregateDataRecord } from '../../shared/data.model';
-import { GeoJson } from '../../shared/geo.model';
 import { DisasterType } from '../disaster-type/disaster-type.enum';
 import { UserRole } from '../user/user-role.enum';
 import { AdminAreaService } from './admin-area.service';
@@ -118,7 +118,7 @@ export class AdminAreaController {
   @UseInterceptors()
   public async addOrUpdateEventAreas(
     @Param() params,
-    @Body() adminAreaGeoJson: GeoJson,
+    @Body() adminAreaGeoJson: FeatureCollection,
   ): Promise<void> {
     await this.eventAreaService.addOrUpdateEventAreas(
       params.countryCodeISO3,
@@ -141,13 +141,12 @@ export class AdminAreaController {
     status: 200,
     description:
       '(Relevant) admin-areas boundaries and attributes for given country, disater-type and lead-time',
-    type: GeoJson,
   })
   @Get(':countryCodeISO3/:disasterType/:adminLevel')
   public async getAdminAreas(
     @Param() params,
     @Query() query,
-  ): Promise<GeoJson> {
+  ): Promise<FeatureCollection> {
     return await this.adminAreaService.getAdminAreas(
       params.countryCodeISO3,
       params.disasterType,

--- a/services/API-service/src/api/admin-area/admin-area.controller.ts
+++ b/services/API-service/src/api/admin-area/admin-area.controller.ts
@@ -31,6 +31,7 @@ import { DisasterType } from '../disaster-type/disaster-type.enum';
 import { UserRole } from '../user/user-role.enum';
 import { AdminAreaService } from './admin-area.service';
 import { AdminAreaParams } from './dto/admin-area.dto';
+import { AdminAreaUpdateResult } from './dto/admin-area.dto';
 import { DeleteAdminAreasDto } from './dto/delete-admin-areas.dto';
 import { AdminAreaUploadDto } from './dto/upload-admin-areas.dto';
 import { EventAreaService } from './services/event-area.service';
@@ -56,6 +57,11 @@ export class AdminAreaController {
     type: 'boolean',
     description:
       'IMPORTANT: Set to true to remove all existing admin-areas for this country and admin-level before adding new ones. WARNING: This may remove event data.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Summary of admin area changes',
+    type: [AdminAreaUpdateResult],
   })
   @Post(':countryCodeISO3/:adminLevel')
   @UseInterceptors()
@@ -86,6 +92,7 @@ export class AdminAreaController {
   })
   @ApiParam({ name: 'countryCodeISO3', required: true, type: 'string' })
   @ApiParam({ name: 'adminLevel', required: true, type: 'number' })
+  @ApiResponse({ status: 200, description: 'Admin areas deleted' })
   @Delete(':countryCodeISO3/:adminLevel')
   @UseInterceptors()
   public async deleteAdminAreas(

--- a/services/API-service/src/api/admin-area/admin-area.controller.ts
+++ b/services/API-service/src/api/admin-area/admin-area.controller.ts
@@ -21,6 +21,8 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+import { Response } from 'express';
+
 import { Roles } from '../../roles.decorator';
 import { RolesGuard } from '../../roles.guard';
 import { AggregateDataRecord } from '../../shared/data.model';
@@ -62,11 +64,12 @@ export class AdminAreaController {
     @Body() body: AdminAreaUploadDto,
     @Query('reset', new ParseBoolPipe({ optional: true }))
     reset: boolean,
-    @Res() res,
-  ): Promise<string> {
+    @Res() res: Response,
+  ) {
     if (body.secret !== process.env.RESET_SECRET) {
       return res.status(HttpStatus.FORBIDDEN).send('Not allowed');
     }
+
     const result = await this.adminAreaService.addOrUpdateAdminAreas(
       params.countryCodeISO3,
       params.adminLevel,
@@ -89,11 +92,12 @@ export class AdminAreaController {
   public async deleteAdminAreas(
     @Param() params: AdminAreaParams,
     @Body() body: DeleteAdminAreasDto,
-    @Res() res,
-  ): Promise<string> {
+    @Res() res: Response,
+  ) {
     if (body.secret !== process.env.RESET_SECRET) {
       return res.status(HttpStatus.FORBIDDEN).send('Not allowed');
     }
+
     const result = await this.adminAreaService.deleteAdminAreas(
       params.countryCodeISO3,
       params.adminLevel,

--- a/services/API-service/src/api/admin-area/admin-area.controller.ts
+++ b/services/API-service/src/api/admin-area/admin-area.controller.ts
@@ -14,7 +14,6 @@ import {
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
-  ApiConsumes,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -56,7 +55,6 @@ export class AdminAreaController {
       'IMPORTANT: Set to true to remove all existing admin-areas for this country and admin-level before adding new ones. USE WITH CARE: This may come with removal of event data.',
   })
   @Post(':countryCodeISO3/:adminLevel')
-  @ApiConsumes()
   @UseInterceptors()
   public async addOrUpdateAdminAreas(
     @Param() params,
@@ -86,7 +84,6 @@ export class AdminAreaController {
   @ApiParam({ name: 'countryCodeISO3', required: true, type: 'string' })
   @ApiParam({ name: 'adminLevel', required: true, type: 'number' })
   @Delete(':countryCodeISO3/:adminLevel')
-  @ApiConsumes()
   @UseInterceptors()
   public async deleteAdminAreas(
     @Param() params,
@@ -117,7 +114,6 @@ export class AdminAreaController {
     description: 'Added and/or Updated admin-areas.',
   })
   @Post('event-areas/:countryCodeISO3/:disasterType')
-  @ApiConsumes()
   @UseInterceptors()
   public async addOrUpdateEventAreas(
     @Param() params,

--- a/services/API-service/src/api/admin-area/admin-area.controller.ts
+++ b/services/API-service/src/api/admin-area/admin-area.controller.ts
@@ -55,7 +55,7 @@ export class AdminAreaController {
     schema: { default: false, type: 'boolean' },
     type: 'boolean',
     description:
-      'IMPORTANT: Set to true to remove all existing admin-areas for this country and admin-level before adding new ones. USE WITH CARE: This may come with removal of event data.',
+      'IMPORTANT: Set to true to remove all existing admin-areas for this country and admin-level before adding new ones. WARNING: This may remove event data.',
   })
   @Post(':countryCodeISO3/:adminLevel')
   @UseInterceptors()
@@ -82,8 +82,7 @@ export class AdminAreaController {
 
   @Roles(UserRole.Admin)
   @ApiOperation({
-    summary:
-      'Delete set of admin-areas. USE WITH CARE: This may come with removal of event data.',
+    summary: 'Delete set of admin-areas. WARNING: This may remove event data.',
   })
   @ApiParam({ name: 'countryCodeISO3', required: true, type: 'string' })
   @ApiParam({ name: 'adminLevel', required: true, type: 'number' })
@@ -114,10 +113,7 @@ export class AdminAreaController {
   })
   @ApiParam({ name: 'countryCodeISO3', required: true, type: 'string' })
   @ApiParam({ name: 'disasterType', required: true, enum: DisasterType })
-  @ApiResponse({
-    status: 201,
-    description: 'Added and/or Updated admin-areas.',
-  })
+  @ApiResponse({ status: 201, description: 'Saved admin areas' })
   @Post('event-areas/:countryCodeISO3/:disasterType')
   @UseInterceptors()
   public async addOrUpdateEventAreas(

--- a/services/API-service/src/api/admin-area/admin-area.controller.ts
+++ b/services/API-service/src/api/admin-area/admin-area.controller.ts
@@ -28,6 +28,7 @@ import { GeoJson } from '../../shared/geo.model';
 import { DisasterType } from '../disaster-type/disaster-type.enum';
 import { UserRole } from '../user/user-role.enum';
 import { AdminAreaService } from './admin-area.service';
+import { AdminAreaParams } from './dto/admin-area.dto';
 import { DeleteAdminAreasDto } from './dto/delete-admin-areas.dto';
 import { AdminAreaUploadDto } from './dto/upload-admin-areas.dto';
 import { EventAreaService } from './services/event-area.service';
@@ -57,7 +58,7 @@ export class AdminAreaController {
   @Post(':countryCodeISO3/:adminLevel')
   @UseInterceptors()
   public async addOrUpdateAdminAreas(
-    @Param() params,
+    @Param() params: AdminAreaParams,
     @Body() body: AdminAreaUploadDto,
     @Query('reset', new ParseBoolPipe({ optional: true }))
     reset: boolean,
@@ -86,7 +87,7 @@ export class AdminAreaController {
   @Delete(':countryCodeISO3/:adminLevel')
   @UseInterceptors()
   public async deleteAdminAreas(
-    @Param() params,
+    @Param() params: AdminAreaParams,
     @Body() body: DeleteAdminAreasDto,
     @Res() res,
   ): Promise<string> {

--- a/services/API-service/src/api/admin-area/admin-area.entity.ts
+++ b/services/API-service/src/api/admin-area/admin-area.entity.ts
@@ -6,7 +6,6 @@ import {
   Index,
   JoinColumn,
   ManyToOne,
-  MultiPolygon,
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
@@ -51,7 +50,7 @@ export class AdminAreaEntity {
     srid: 4326,
     nullable: true,
   })
-  public geom: MultiPolygon;
+  public geom: () => string;
 
   @OneToMany(
     (): typeof EventPlaceCodeEntity => EventPlaceCodeEntity,

--- a/services/API-service/src/api/admin-area/admin-area.service.ts
+++ b/services/API-service/src/api/admin-area/admin-area.service.ts
@@ -69,6 +69,7 @@ export class AdminAreaService {
 
         adminArea.countryCodeISO3 = countryCodeISO3;
         adminArea.adminLevel = adminLevel;
+        adminArea.name = properties[`ADM${adminLevel}_EN`];
         adminArea.placeCode = properties[`ADM${adminLevel}_PCODE`];
         adminArea.placeCodeParent =
           properties[`ADM${adminLevel - 1}_PCODE`] ?? null;

--- a/services/API-service/src/api/admin-area/admin-area.service.ts
+++ b/services/API-service/src/api/admin-area/admin-area.service.ts
@@ -137,7 +137,6 @@ export class AdminAreaService {
     if (placeCodes && placeCodes.length > 0) {
       whereFilters['placeCode'] = In(placeCodes);
     }
-    console.log('whereFilters: ', whereFilters);
     const adminAreasWithActiveEvents = await this.adminAreaRepository
       .createQueryBuilder('area')
       .innerJoin(
@@ -147,12 +146,11 @@ export class AdminAreaService {
       )
       .where(whereFilters)
       .getMany();
-    console.log('adminAreasWithActiveEvents: ', adminAreasWithActiveEvents);
 
     // If any active events found, throw ForbiddenException to protect data
     if (adminAreasWithActiveEvents.length > 0) {
       const activePlaceCodes = adminAreasWithActiveEvents.map(
-        (area) => area.placeCode,
+        ({ placeCode }) => placeCode,
       );
       throw new ForbiddenException(
         `Cannot delete admin areas with active events. Found ${adminAreasWithActiveEvents.length} areas with active events: ${activePlaceCodes.join(', ')}`,

--- a/services/API-service/src/api/admin-area/dto/admin-area.dto.ts
+++ b/services/API-service/src/api/admin-area/dto/admin-area.dto.ts
@@ -1,6 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 import { AdminLevel } from '../../country/admin-level.enum';
 
 export interface AdminAreaParams {
   countryCodeISO3: string;
   adminLevel: AdminLevel;
+}
+
+export class AdminAreaUpdateResult {
+  @ApiProperty({ example: 0 })
+  public upserted: number;
+
+  @ApiProperty({ example: 0 })
+  public deleted: number;
+
+  @ApiProperty({ example: 0 })
+  public untouched: number;
 }

--- a/services/API-service/src/api/admin-area/dto/admin-area.dto.ts
+++ b/services/API-service/src/api/admin-area/dto/admin-area.dto.ts
@@ -1,0 +1,6 @@
+import { AdminLevel } from '../../country/admin-level.enum';
+
+export interface AdminAreaParams {
+  countryCodeISO3: string;
+  adminLevel: AdminLevel;
+}

--- a/services/API-service/src/api/admin-area/dto/delete-admin-areas.dto.ts
+++ b/services/API-service/src/api/admin-area/dto/delete-admin-areas.dto.ts
@@ -14,7 +14,7 @@ export class DeleteAdminAreasDto {
   secret: string;
 
   @ApiProperty({
-    description: 'Array of placeCodes to be deleted',
+    description: 'Array of place codes to delete',
     example: ['UG123', 'UG456'],
   })
   placeCodes: string[];

--- a/services/API-service/src/api/admin-area/dto/delete-admin-areas.dto.ts
+++ b/services/API-service/src/api/admin-area/dto/delete-admin-areas.dto.ts
@@ -2,10 +2,12 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { IsNotEmpty, IsString } from 'class-validator';
 
+import { PLACEHOLDER_SECRET } from '../../../config';
+
 export class DeleteAdminAreasDto {
   @ApiProperty({
     description: 'Secret key for authorization',
-    example: 'fill_in_secret',
+    example: PLACEHOLDER_SECRET,
   })
   @IsString()
   @IsNotEmpty()

--- a/services/API-service/src/api/admin-area/dto/upload-admin-areas.dto.ts
+++ b/services/API-service/src/api/admin-area/dto/upload-admin-areas.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 import { IsNotEmpty, IsString } from 'class-validator';
+import { FeatureCollection } from 'typeorm';
 
 import { PLACEHOLDER_SECRET } from '../../../config';
-import { GeoJson } from '../../../shared/geo.model';
 
 export class AdminAreaUploadDto {
   @ApiProperty({
@@ -43,5 +43,5 @@ export class AdminAreaUploadDto {
       ],
     },
   })
-  adminAreaGeoJson: GeoJson;
+  adminAreaGeoJson: FeatureCollection;
 }

--- a/services/API-service/src/api/admin-area/dto/upload-admin-areas.dto.ts
+++ b/services/API-service/src/api/admin-area/dto/upload-admin-areas.dto.ts
@@ -2,12 +2,13 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { IsNotEmpty, IsString } from 'class-validator';
 
+import { PLACEHOLDER_SECRET } from '../../../config';
 import { GeoJson } from '../../../shared/geo.model';
 
 export class AdminAreaUploadDto {
   @ApiProperty({
     description: 'Secret key for authorization',
-    example: 'fill_in_secret',
+    example: PLACEHOLDER_SECRET,
   })
   @IsString()
   @IsNotEmpty()

--- a/services/API-service/src/api/admin-area/event-area.entity.ts
+++ b/services/API-service/src/api/admin-area/event-area.entity.ts
@@ -5,7 +5,6 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
-  MultiPolygon,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 
@@ -38,5 +37,5 @@ export class EventAreaEntity {
 
   @ApiProperty()
   @Column('geometry', { spatialFeatureType: 'MultiPolygon', srid: 4326 })
-  public geom: MultiPolygon;
+  public geom: () => string;
 }

--- a/services/API-service/src/api/admin-area/services/event-area.service.ts
+++ b/services/API-service/src/api/admin-area/services/event-area.service.ts
@@ -2,9 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import {
+  Geometry,
+  GeometryCollection,
   InsertResult,
   MoreThanOrEqual,
-  MultiPolygon,
   Repository,
 } from 'typeorm';
 import { FeatureCollection } from 'typeorm';
@@ -61,7 +62,10 @@ export class EventAreaService {
             disasterType,
             eventAreaName: area.properties[`name`],
             geom: (): string =>
-              this.geomFunction((area.geometry as MultiPolygon).coordinates), // REFACTOR: remove typecast
+              this.geomFunction(
+                (area.geometry as Exclude<Geometry, GeometryCollection>) // REFACTOR: remove typecast
+                  .coordinates,
+              ),
           })
           .execute();
       }),

--- a/services/API-service/src/api/point-data/point-data.controller.ts
+++ b/services/API-service/src/api/point-data/point-data.controller.ts
@@ -22,10 +22,11 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+import { FeatureCollection } from 'typeorm';
+
 import { Roles } from '../../roles.decorator';
 import { RolesGuard } from '../../roles.guard';
 import { FILE_UPLOAD_API_FORMAT } from '../../shared/file-upload-api-format';
-import { GeoJson } from '../../shared/geo.model';
 import { DisasterType } from '../disaster-type/disaster-type.enum';
 import { UserRole } from '../user/user-role.enum';
 import { UploadDynamicPointDataDto } from './dto/upload-asset-exposure-status.dto';
@@ -50,10 +51,12 @@ export class PointDataController {
     status: 200,
     description:
       'Retrieved point data locations and attributes for given country and point data layer',
-    type: GeoJson,
   })
   @Get(':pointDataCategory/:countryCodeISO3')
-  public async getPointData(@Param() params, @Query() query): Promise<GeoJson> {
+  public async getPointData(
+    @Param() params,
+    @Query() query,
+  ): Promise<FeatureCollection> {
     return await this.pointDataService.getPointDataByCountry(
       params.pointDataCategory,
       params.countryCodeISO3,

--- a/services/API-service/src/api/point-data/point-data.service.ts
+++ b/services/API-service/src/api/point-data/point-data.service.ts
@@ -3,8 +3,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { validate } from 'class-validator';
 import { IsNull, MoreThanOrEqual, Repository } from 'typeorm';
+import { FeatureCollection } from 'typeorm';
 
-import { GeoJson } from '../../shared/geo.model';
 import { HelperService } from '../../shared/helper.service';
 import { DisasterType } from '../disaster-type/disaster-type.enum';
 import { WhatsappService } from '../notification/whatsapp/whatsapp.service';
@@ -52,7 +52,7 @@ export class PointDataService {
     pointDataCategory: PointDataCategory,
     countryCodeISO3: string,
     disasterType: DisasterType,
-  ): Promise<GeoJson> {
+  ): Promise<FeatureCollection> {
     const attributes = [];
     const pointDto = this.getPointDto(pointDataCategory);
 
@@ -118,7 +118,7 @@ export class PointDataService {
 
     const pointData = await pointDataQuery.getRawMany();
 
-    return this.helperService.toGeojson(pointData);
+    return this.helperService.getFeatureCollection(pointData);
   }
 
   private getPointDto(pointDataCategory: PointDataCategory) {

--- a/services/API-service/src/api/typhoon-track/typhoon-track.controller.ts
+++ b/services/API-service/src/api/typhoon-track/typhoon-track.controller.ts
@@ -16,9 +16,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+import { FeatureCollection } from 'typeorm';
+
 import { Roles } from '../../roles.decorator';
 import { RolesGuard } from '../../roles.guard';
-import { GeoJson } from '../../shared/geo.model';
 import { UserRole } from '../user/user-role.enum';
 import { UploadTyphoonTrackDto } from './dto/upload-typhoon-track';
 import { TyphoonTrackEntity } from './typhoon-track.entity';
@@ -62,13 +63,12 @@ export class TyphoonTrackController {
     status: 200,
     description:
       'Typhoon track data for given country and leadtime in GEOJSON format.',
-    type: GeoJson,
   })
   @Get(':countryCodeISO3')
   public async getTyphoonTrack(
     @Param() params,
     @Query() query,
-  ): Promise<GeoJson> {
+  ): Promise<FeatureCollection> {
     return await this.typhoonTrackService.getTyphoonTrack(
       params.countryCodeISO3,
       query.eventName,

--- a/services/API-service/src/api/typhoon-track/typhoon-track.entity.ts
+++ b/services/API-service/src/api/typhoon-track/typhoon-track.entity.ts
@@ -5,10 +5,11 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  Point,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 
-import { GeoJson } from '../../shared/geo.model';
+import { point } from '../../shared/geo.model';
 import { LeadTime } from '../admin-area-dynamic-data/enum/lead-time.enum';
 import { CountryEntity } from '../country/country.entity';
 
@@ -53,7 +54,7 @@ export class TyphoonTrackEntity {
   @Column({ nullable: true })
   public eventName: string;
 
-  @ApiProperty({ example: new GeoJson() })
-  @Column('json', { nullable: true })
-  public geom: JSON;
+  @ApiProperty({ example: point })
+  @Column('json', { nullable: true }) // REFACTOR: convert to Point type
+  public geom: Point;
 }

--- a/services/API-service/src/api/typhoon-track/typhoon-track.service.ts
+++ b/services/API-service/src/api/typhoon-track/typhoon-track.service.ts
@@ -7,9 +7,9 @@ import {
   MoreThanOrEqual,
   Repository,
 } from 'typeorm';
+import { FeatureCollection } from 'typeorm';
 
 import { DisasterSpecificProperties } from '../../shared/data.model';
-import { GeoJson } from '../../shared/geo.model';
 import { HelperService } from '../../shared/helper.service';
 import { DisasterType } from '../disaster-type/disaster-type.enum';
 import { TyphoonCategory } from './dto/trackpoint-details';
@@ -77,7 +77,7 @@ export class TyphoonTrackService {
   public async getTyphoonTrack(
     countryCodeISO3: string,
     eventName: string,
-  ): Promise<GeoJson> {
+  ): Promise<FeatureCollection> {
     const filters = await this.getTrackFilters(countryCodeISO3, eventName);
     const typhoonTrackPoints = await this.typhoonTrackRepository.find({
       select: [
@@ -93,7 +93,7 @@ export class TyphoonTrackService {
       where: filters,
     });
 
-    return this.helperService.toGeojson(typhoonTrackPoints);
+    return this.helperService.getFeatureCollection(typhoonTrackPoints);
   }
 
   public async shouldSendNotification(

--- a/services/API-service/src/api/waterpoints/waterpoints.controller.ts
+++ b/services/API-service/src/api/waterpoints/waterpoints.controller.ts
@@ -8,9 +8,9 @@ import {
 } from '@nestjs/swagger';
 
 import { AxiosResponse } from 'axios';
+import { FeatureCollection } from 'typeorm';
 
 import { RolesGuard } from '../../roles.guard';
-import { GeoJson } from '../../shared/geo.model';
 import { WaterpointsService } from './waterpoints.service';
 
 @ApiBearerAuth()
@@ -36,10 +36,7 @@ export class WaterpointsController {
   @Get(':countryCodeISO3')
   public async getWaterpoints(
     @Param() params,
-  ): Promise<AxiosResponse<GeoJson>> {
-    const result = await this.waterpointsService.getWaterpoints(
-      params.countryCodeISO3,
-    );
-    return result;
+  ): Promise<AxiosResponse<FeatureCollection>> {
+    return this.waterpointsService.getWaterpoints(params.countryCodeISO3);
   }
 }

--- a/services/API-service/src/api/waterpoints/waterpoints.service.ts
+++ b/services/API-service/src/api/waterpoints/waterpoints.service.ts
@@ -2,8 +2,8 @@ import { HttpService } from '@nestjs/axios';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 
 import { AxiosResponse } from 'axios';
+import { FeatureCollection } from 'typeorm';
 
-import { GeoJson } from '../../shared/geo.model';
 import { CountryService } from '../country/country.service';
 
 @Injectable()
@@ -20,7 +20,7 @@ export class WaterpointsService {
 
   public async getWaterpoints(
     countryCodeISO3: string,
-  ): Promise<AxiosResponse<GeoJson>> {
+  ): Promise<AxiosResponse<FeatureCollection>> {
     const country =
       await this.countryService.getBoundingBoxWkt(countryCodeISO3);
     if (!country) {

--- a/services/API-service/src/config.ts
+++ b/services/API-service/src/config.ts
@@ -2,6 +2,7 @@ export const DEBUG =
   ['production', 'test', 'ci'].indexOf(process.env.NODE_ENV) < 0; // true if NODE_ENV is not in list
 export const PORT = 3000;
 export const DUNANT_EMAIL = 'dunant@redcross.nl';
+export const PLACEHOLDER_SECRET = 'fill_in_secret';
 
 // Configure Internal and External API URL's
 // ---------------------------------------------------------------------------

--- a/services/API-service/src/scripts/dto/mock-input.dto.ts
+++ b/services/API-service/src/scripts/dto/mock-input.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
+import { PLACEHOLDER_SECRET } from '../../config';
 import {
   DroughtScenario,
   FlashFloodsScenario,
@@ -22,7 +23,7 @@ const deduplicatedScenarios = Array.from(new Set(combinedScenarios)).join(
 );
 
 export class MockInputDto {
-  @ApiProperty({ example: 'fill_in_secret' })
+  @ApiProperty({ example: PLACEHOLDER_SECRET })
   @IsNotEmpty()
   @IsString()
   public readonly secret: string;

--- a/services/API-service/src/scripts/dto/reset.dto.ts
+++ b/services/API-service/src/scripts/dto/reset.dto.ts
@@ -2,8 +2,10 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { IsNotEmpty, IsString } from 'class-validator';
 
+import { PLACEHOLDER_SECRET } from '../../config';
+
 export class ResetDto {
-  @ApiProperty({ example: 'fill_in_secret' })
+  @ApiProperty({ example: PLACEHOLDER_SECRET })
   @IsNotEmpty()
   @IsString()
   public readonly secret: string;

--- a/services/API-service/src/shared/data.model.ts
+++ b/services/API-service/src/shared/data.model.ts
@@ -1,8 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+import { Geometry } from 'typeorm';
+
 import { LeadTime } from '../api/admin-area-dynamic-data/enum/lead-time.enum';
 import { AlertLevel } from '../api/event/enum/alert-level.enum';
-import { Geometry } from './geo.model';
 
 export class AdminAreaRecord {
   public placeCode: string;

--- a/services/API-service/src/shared/geo.model.ts
+++ b/services/API-service/src/shared/geo.model.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { Point } from 'typeorm';
 
 export class Poi {
   public code: string;
@@ -21,31 +21,7 @@ export class RedCrossBranch extends Poi {
   public contactNumber: string;
 }
 
-export class Geometry {
-  public type: string;
-  public coordinates: number[];
-}
-
-export class GeoJsonFeature {
-  public type: string;
-  public geometry: Geometry;
-  public properties: object;
-}
-
-export class GeoJson {
-  @ApiProperty({ example: 'FeatureCollection' })
-  public type: string;
-  @ApiProperty({
-    example: [
-      {
-        type: 'Feature',
-        geometry: { type: 'Point', coordinates: [] },
-        properties: {},
-      },
-    ],
-  })
-  public features: GeoJsonFeature[];
-}
+export const point: Point = { type: 'Point', coordinates: [] };
 
 export class BoundingBox {
   public type: string;

--- a/services/API-service/src/shared/helper.service.ts
+++ b/services/API-service/src/shared/helper.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
 
 import csv from 'csv-parser';
-import { DataSource } from 'typeorm';
+import { DataSource, Geometry } from 'typeorm';
+import { FeatureCollection } from 'typeorm';
 import { Readable } from 'typeorm/platform/PlatformTools';
 
 import { AdminAreaDynamicDataEntity } from '../api/admin-area-dynamic-data/admin-area-dynamic-data.entity';
@@ -12,27 +13,21 @@ import {
 import { DisasterType } from '../api/disaster-type/disaster-type.enum';
 import { LastUploadDateDto } from '../api/event/dto/last-upload-date.dto';
 import { NumberFormat } from './enums/number-format.enum';
-import { GeoJson, GeoJsonFeature } from './geo.model';
 
 @Injectable()
 export class HelperService {
   public constructor(private dataSource: DataSource) {}
 
-  public toGeojson(rawResult): GeoJson {
-    const geoJson: GeoJson = { type: 'FeatureCollection', features: [] };
-    rawResult.forEach((i): void => {
-      const feature: GeoJsonFeature = {
-        type: 'Feature',
-        geometry: i.geom,
-        properties: {},
-      };
-      delete i.geom;
-      feature.properties = i;
-      geoJson.features.push(feature);
-    });
-
-    return geoJson;
-  }
+  public getFeatureCollection = (
+    features: { geom: Geometry }[],
+  ): FeatureCollection => ({
+    type: 'FeatureCollection',
+    features: features.map(({ geom: geometry, ...properties }) => ({
+      type: 'Feature',
+      geometry,
+      properties,
+    })),
+  });
 
   public getUploadCutoffMoment(disasterType: DisasterType, date: Date): Date {
     const lastInterval = new Date(date);


### PR DESCRIPTION
## Describe your changes

This PR includes refactors on #2190.
1. remove unnecessary use of ApiConsumes
2. use PLACEHOLDER_SECRET for shared string
3. use AdminAreaParams interface
4. use express Response type
5. update swagger descriptions
6. use typeorm geojson types
7. use bulk upsert
8. clean up unnecessary console.logs

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review