### PR TITLE
fix: event area aggregates should show 0 instead of NA

### DIFF
--- a/interfaces/IBF-dashboard/src/app/components/aggregates/aggregates.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/aggregates/aggregates.component.html
@@ -113,7 +113,7 @@
                 </ion-label>
               } @else {
                 <ion-label class="ion-text-right m-0" data-test="aggregate-na">
-                  {{ 'aggregates-component.not-applicable' | translate }}
+                  {{ 'aggregates-component.default-value' | translate }}
                 </ion-label>
               }
             </ion-item>

--- a/interfaces/IBF-dashboard/src/assets/i18n/en.json
+++ b/interfaces/IBF-dashboard/src/assets/i18n/en.json
@@ -1,8 +1,6 @@
 {
   "app-name": "IBF-dashboard",
-  "common": {
-    "version": "Version"
-  },
+  "common": { "version": "Version" },
   "export-view": {
     "title": "Export view",
     "instruction": "In order to export the current view of the IBF-dashboard, you will need to take a screenshot.",
@@ -34,10 +32,7 @@
     "note": "NOTE: This portal works best on desktop or tablet using Chrome, Firefox, Safari and Microsoft Edge.<br>The portal is not compatible with Internet Explorer.<br>The portal is not optimized for mobile phones yet.",
     "forgot-password": "Forgot password?",
     "forgot-password-message": "If you forgot your password please send a request to ",
-    "environment-label": {
-      "production": "Live",
-      "stage": "Demo"
-    }
+    "environment-label": { "production": "Live", "stage": "Demo" }
   },
   "user-state": {
     "logged-in-as": "Logged in as:",
@@ -63,10 +58,7 @@
         "alert-error-no-secret": "Reset secret cannot be empty."
       }
     },
-    "triggered-message": {
-      "yes": "TRIGGERED",
-      "no": "NON-TRIGGERED"
-    },
+    "triggered-message": { "yes": "TRIGGERED", "no": "NON-TRIGGERED" },
     "screen-orientation": {
       "mobile": {
         "title": "IBF Portal - Mobile Phones",
@@ -158,9 +150,7 @@
         "no-data": "No exposure data available",
         "set-by": "<strong>Set by:</strong> {{ userTriggerName }} on {{ userTriggerDate }}"
       },
-      "set-trigger": {
-        "btn-text": "Set trigger"
-      }
+      "set-trigger": { "btn-text": "Set trigger" }
     },
     "floods": {
       "about-button-label": "About trigger",
@@ -288,9 +278,7 @@
       "delete-confirm": "Confirm",
       "delete-successs": "Deleting notification succeeded",
       "delete-fail": "Deleting notification failed",
-      "photo-popup": {
-        "title": "Community notification - photo"
-      }
+      "photo-popup": { "title": "Community notification - photo" }
     },
     "river-gauge": {
       "unit": "m",
@@ -311,10 +299,6 @@
       "threshold-description": "Trigger activation threshold"
     }
   },
-  "breadcrumbs": {
-    "national-view": "National View"
-  },
-  "layers-menu": {
-    "menu-toggle-label": "Layers"
-  }
+  "breadcrumbs": { "national-view": "National View" },
+  "layers-menu": { "menu-toggle-label": "Layers" }
 }

--- a/interfaces/IBF-dashboard/src/assets/i18n/en.json
+++ b/interfaces/IBF-dashboard/src/assets/i18n/en.json
@@ -77,7 +77,7 @@
     "national-view": "National View",
     "predicted": "Predicted",
     "plural-suffix": "(s)",
-    "not-applicable": "N/A"
+    "default-value": "0"
   },
   "disclaimer-approximate-component": {
     "message": "All numbers are approximate and meant to be used as guidance."

--- a/tests/e2e/Pages/AggregatesComponent.ts
+++ b/tests/e2e/Pages/AggregatesComponent.ts
@@ -83,12 +83,9 @@ class AggregatesComponent extends DashboardPage {
     expect(iconLayerCount).toBe(aggregates.length);
 
     // Loop through the layers and check if they are present with correct data
-    // TODO: remove this filter after fixing AB#35929
-    if (!['flash-floods', 'floods'].includes(disasterType.name)) {
-      for (const affectedNumber of affectedNumbers) {
-        const affectedNumberText = await affectedNumber.textContent();
-        expect(affectedNumberText).toContain('0');
-      }
+    for (const affectedNumber of affectedNumbers) {
+      const affectedNumberText = await affectedNumber.textContent();
+      expect(affectedNumberText).toContain('0');
     }
     // Loop through the layers and check if they are present with correct names
     for (const aggregate of aggregates) {


### PR DESCRIPTION
## Describe your changes

According to bug [AB#35929](https://dev.azure.com/redcrossnl/IBF/_workitems/edit/35929), event area aggregates should show 0 instead of NA.

The dashboard used to show the aggregate value received from the API, or fall back to NA to indicate that the value was unavailable.

Since event areas,
1. `/admin-areas/aggregates` API does not return a list of admin areas.
2. When events are found, the API returns a list of aggregate values. The dashboard shows the values (as expected).
3. When no events are found, the API returns an empty list. The dashboard falls back to NA (because no values in the API response).

I considered the following solutions,
1. The API should return a list of aggregate values, with aggregate value 0. The aggregates API response requires 3 properties,
```json
{
    "placeCode": "UG06023",
    "indicator": "population_affected",
    "value": 43
}
```
The values for `indicator` and `value` are clear. The value for `placeCode` is unclear. I expect `placeCode` to return a valid `placeCode` value. When I checked the API response for the case when events are found,
```json
{
    "placeCode": "Rumphi",
    "indicator": "population_affected",
    "value": 434
}
```
The `placeCode` value is the event name. _Let's assume this makes sense._ When there are no events, I don't have an event name to fill the `placeCode` value. The dead end: either remove `placeCode` from the aggregates response _or_ fill the requirements gap introduced by event areas.

2. The expected behaviour is relatively easily achieved by making the dashboard fallback to 0 instead of NA. This PR applies this solution. This solution assumes that the NA fallback is not a requirement but an implementation detail.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review