### PR TITLE
fix: align IBF version-nr

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "IBF-system",
-  "version": "0.320.2",
+  "version": "0.320.3",
   "private": true,
   "scripts": {
     "start:services": "docker compose up -d",


### PR DESCRIPTION
## Describe your changes

The bump-version workflow fails when the tag is not in line with the version-nr in package.json. Not sure how that happened, but this fix is meant to re-align it again.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review

