### PR TITLE
fix: ionic translate error

### DIFF
--- a/interfaces/IBF-dashboard/src/app/pages/dashboard/dashboard.page.html
+++ b/interfaces/IBF-dashboard/src/app/pages/dashboard/dashboard.page.html
@@ -27,7 +27,7 @@
         lines="full"
         target="_blank"
       >
-        <ion-label [translate]="'common.version'"></ion-label>
+        <ion-label>{{ 'common.version' | translate }}</ion-label>
         <ion-text>{{ version }}</ion-text>
       </ion-item>
       <app-country-switcher
@@ -39,16 +39,21 @@
       ></app-backend-mock-scenario>
     </ion-list>
     <ion-list class="ion-no-padding" [class.ion-hide]="!isDev">
-      <ion-item href="/log" lines="full" target="_blank">
-        <ion-label
-          [translate]="'activation-page.activation-report'"
-        ></ion-label>
+      <ion-item
+        href="/log"
+        lines="full"
+        target="_blank"
+        [translate]="'activation-page.activation-report'"
+      >
       </ion-item>
     </ion-list>
     <ion-list class="ion-no-padding" [class.ion-hide]="!isDev">
-      <ion-item href="/status-report" lines="full" target="_blank">
-        <ion-label [translate]="'status-report-page.dev-menu-link'"></ion-label>
-      </ion-item>
+      <ion-item
+        href="/status-report"
+        lines="full"
+        target="_blank"
+        [translate]="'status-report-page.dev-menu-link'"
+      ></ion-item>
     </ion-list>
   </ion-content>
 </ion-menu>


### PR DESCRIPTION
## Describe your changes

For reasons I don't understand, ngx-translate repeats the output on ion-label, switching from directive to pipe solves the issue.

### Context
@ionic/angular was updated from 8.5.2 to 8.6.1 and ngx-translate was not updated.

The latest docs all use standalone components. We should migrate from _modules_ to _standalone components_ before we lose complete support for _modules_.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review