### PR TITLE
fix: typo in lesotho forecast source

### DIFF
--- a/services/API-service/src/scripts/json/countries.json
+++ b/services/API-service/src/scripts/json/countries.json
@@ -1242,7 +1242,7 @@
         "forecastSource": {
           "label": "ECMWF seasonal forecast monthly statistics",
           "url": "https://www.ecmwf.int",
-          "setTriggerSource": "the Lesotho Methodological Services seasonal forecast"
+          "setTriggerSource": "the Lesotho Meteorological Services seasonal forecast"
         },
         "enableEarlyActions": false,
         "eapLink": "https://adore.ifrc.org/Download.aspx?FileId=617501"


### PR DESCRIPTION
## Describe your changes

This PR fixes a typo in the forecast source for Lesotho.