### PR TITLE
fix: add titles to upload, download, and close buttons

### DIFF
--- a/interfaces/IBF-dashboard/src/app/components/layer-control-info-popover/layer-control-info-popover.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/layer-control-info-popover/layer-control-info-popover.component.html
@@ -12,7 +12,12 @@
           userRole === UserRole.LocalAdmin ||
           userRole === UserRole.Operator
         ) {
-          <ion-button fill="clear" color="ibf-white" (click)="upload()">
+          <ion-button
+            fill="clear"
+            color="ibf-white"
+            (click)="upload()"
+            title="Upload data"
+          >
             <ion-icon slot="icon-only" name="cloud-upload"></ion-icon>
             <input
               type="file"
@@ -23,7 +28,12 @@
           </ion-button>
         }
 
-        <ion-button fill="clear" color="ibf-white" (click)="download()">
+        <ion-button
+          fill="clear"
+          color="ibf-white"
+          (click)="download()"
+          title="Download data"
+        >
           <ion-icon slot="icon-only" name="cloud-download"></ion-icon>
         </ion-button>
       }
@@ -32,6 +42,7 @@
         color="ibf-white"
         (click)="closePopover()"
         data-testid="close-matrix-icon"
+        title="Close"
       >
         <ion-icon slot="icon-only" size="large" name="close-circle"></ion-icon>
       </ion-button>


### PR DESCRIPTION
## Describe your changes

This PR adds titles on hover to the upload, download, and close buttons.