### PR TITLE
feat: enable multi-threshold for ethiopia flood

### DIFF
--- a/services/API-service/src/scripts/json/countries.json
+++ b/services/API-service/src/scripts/json/countries.json
@@ -653,6 +653,18 @@
             "color": "ibf-no-alert-primary",
             "value": 0
           },
+          "min": {
+            "label": "Low warning issued",
+            "color": "fiveten-yellow-500",
+            "textColor": "fiveten-yellow-700",
+            "value": 0.3
+          },
+          "med": {
+            "label": "Medium warning issued",
+            "color": "fiveten-orange-500",
+            "textColor": "fiveten-orange-700",
+            "value": 0.7
+          },
           "max": {
             "label": "Trigger issued",
             "color": "ibf-glofas-trigger",

--- a/services/API-service/src/scripts/mock-data/floods/ETH/trigger/G1067/glofas-station.json
+++ b/services/API-service/src/scripts/mock-data/floods/ETH/trigger/G1067/glofas-station.json
@@ -5,5 +5,19 @@
     "eapAlertClass": "max",
     "forecastReturnPeriod": 10,
     "triggerLevel": 4000
+  },
+  {
+    "stationCode": "G1053",
+    "forecastLevel": 2800,
+    "eapAlertClass": "med",
+    "forecastReturnPeriod": 5,
+    "triggerLevel": 3000
+  },
+  {
+    "stationCode": "G1045",
+    "forecastLevel": 2000,
+    "eapAlertClass": "min",
+    "forecastReturnPeriod": 10,
+    "triggerLevel": 4000
   }
 ]

--- a/services/API-service/src/scripts/mock-data/floods/ETH/trigger/glofas-stations-no-alert.json
+++ b/services/API-service/src/scripts/mock-data/floods/ETH/trigger/glofas-stations-no-alert.json
@@ -1,84 +1,77 @@
 [
   {
-    "stationCode": "G1045",
-    "forecastLevel": 0.0,
-    "eapAlertClass": "no",
-    "forecastReturnPeriod": null,
-    "triggerLevel": 4000
-  },
-  {
     "stationCode": "G1074",
-    "forecastLevel": 0.0,
+    "forecastLevel": 0,
     "eapAlertClass": "no",
     "forecastReturnPeriod": null,
     "triggerLevel": 4000
   },
   {
     "stationCode": "G1603",
-    "forecastLevel": 0.0,
+    "forecastLevel": 0,
     "eapAlertClass": "no",
     "forecastReturnPeriod": null,
     "triggerLevel": 4000
   },
   {
     "stationCode": "G1901",
-    "forecastLevel": 0.0,
+    "forecastLevel": 0,
     "eapAlertClass": "no",
     "forecastReturnPeriod": null,
     "triggerLevel": 4000
   },
   {
     "stationCode": "G1902",
-    "forecastLevel": 0.0,
+    "forecastLevel": 0,
     "eapAlertClass": "no",
     "forecastReturnPeriod": null,
     "triggerLevel": 4000
   },
   {
     "stationCode": "G1904",
-    "forecastLevel": 0.0,
+    "forecastLevel": 0,
     "eapAlertClass": "no",
     "forecastReturnPeriod": null,
     "triggerLevel": 4000
   },
   {
     "stationCode": "G4953",
-    "forecastLevel": 0.0,
+    "forecastLevel": 0,
     "eapAlertClass": "no",
     "forecastReturnPeriod": null,
     "triggerLevel": 4000
   },
   {
     "stationCode": "G5056",
-    "forecastLevel": 0.0,
+    "forecastLevel": 0,
     "eapAlertClass": "no",
     "forecastReturnPeriod": null,
     "triggerLevel": 4000
   },
   {
     "stationCode": "G5081",
-    "forecastLevel": 0.0,
+    "forecastLevel": 0,
     "eapAlertClass": "no",
     "forecastReturnPeriod": null,
     "triggerLevel": 4000
   },
   {
     "stationCode": "G5115",
-    "forecastLevel": 0.0,
+    "forecastLevel": 0,
     "eapAlertClass": "no",
     "forecastReturnPeriod": null,
     "triggerLevel": 4000
   },
   {
     "stationCode": "G6107",
-    "forecastLevel": 0.0,
+    "forecastLevel": 0,
     "eapAlertClass": "no",
     "forecastReturnPeriod": null,
     "triggerLevel": 4000
   },
   {
     "stationCode": "G6109",
-    "forecastLevel": 0.0,
+    "forecastLevel": 0,
     "eapAlertClass": "no",
     "forecastReturnPeriod": null,
     "triggerLevel": 4000


### PR DESCRIPTION
## Describe your changes

Related to https://github.com/rodekruis/Anticipatory-Action/issues/1226

This PR includes,
1. Configures the multi-level threshold feature for Ethiopia flood
2. Updates the `trigger` mock scenarios to include `med` and `min` GloFAS stations

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests wherever relevant
- [ ] I have made sure that all automated checks pass before requesting a review