### PR TITLE
fix: use text colour for low warning

### DIFF
--- a/services/API-service/src/api/notification/email/mjml/body-event.ts
+++ b/services/API-service/src/api/notification/email/mjml/body-event.ts
@@ -5,8 +5,8 @@ import { ForecastSource } from '../../../country/country-disaster.entity';
 import { DisasterType } from '../../../disaster-type/disaster-type.enum';
 import { LastUploadDateDto } from '../../../event/dto/last-upload-date.dto';
 import {
-  ALERT_LEVEL_COLOUR,
   ALERT_LEVEL_LABEL,
+  ALERT_LEVEL_TEXT_COLOUR,
   ALERT_LEVEL_WARNINGS,
   AlertLevel,
 } from '../../../event/enum/alert-level.enum';
@@ -275,7 +275,7 @@ export const getMjmlEventListBody = async (
         eapLink,
 
         disasterIssuedLabel: ALERT_LEVEL_LABEL[alertLevel],
-        textColour: ALERT_LEVEL_COLOUR[alertLevel],
+        textColour: ALERT_LEVEL_TEXT_COLOUR[alertLevel],
         forecastSource: countryDisasterSetting.forecastSource,
         userTriggerData: userTrigger // Hide forecast source for "set" triggers
           ? userTriggerData

--- a/services/API-service/src/api/notification/email/mjml/event-admin-area-table.ts
+++ b/services/API-service/src/api/notification/email/mjml/event-admin-area-table.ts
@@ -1,8 +1,8 @@
 import { AlertArea } from '../../../../shared/data.model';
 import { NumberFormat } from '../../../../shared/enums/number-format.enum';
 import {
-  ALERT_LEVEL_COLOUR,
   ALERT_LEVEL_LABEL,
+  ALERT_LEVEL_TEXT_COLOUR,
   AlertLevel,
 } from '../../../event/enum/alert-level.enum';
 import { IndicatorMetadataEntity } from '../../../metadata/indicator-metadata.entity';
@@ -39,7 +39,7 @@ const getMjmlEventAdminAreaTable = ({
   const titleElement = getTextElement({
     content: `${icon} <strong>${ALERT_LEVEL_LABEL[alertLevel]}: ${eventName}</strong>`,
     attributes: {
-      color: ALERT_LEVEL_COLOUR[alertLevel],
+      color: ALERT_LEVEL_TEXT_COLOUR[alertLevel],
       'container-background-color': COLOR_WHITE,
       align: 'center',
       padding: '8px 24px',


### PR DESCRIPTION
## Describe your changes

Use text colour for event titles in email. Noticable for low warning.