### PR TITLE
feat: old login

### DIFF
--- a/interfaces/IBF-dashboard/src/app/analytics/analytics.enum.ts
+++ b/interfaces/IBF-dashboard/src/app/analytics/analytics.enum.ts
@@ -1,5 +1,6 @@
 export enum AnalyticsPage {
   activationLog = 'activation-Log',
+  backdoor = 'backdoor',
   dashboard = 'dashboard',
   login = 'login',
   manage = 'manage',

--- a/interfaces/IBF-dashboard/src/app/auth/auth.guard.ts
+++ b/interfaces/IBF-dashboard/src/app/auth/auth.guard.ts
@@ -30,7 +30,7 @@ export class AuthGuard {
 
   checkLogin(url: string): boolean {
     if (this.authService.isLoggedIn) {
-      if (url === '/login') {
+      if (url.startsWith('/login')) {
         void this.router.navigate(['/']);
       }
 
@@ -39,7 +39,7 @@ export class AuthGuard {
       }
 
       return true;
-    } else if (url === '/login') {
+    } else if (url.startsWith('/login')) {
       return true;
     }
 

--- a/interfaces/IBF-dashboard/src/app/auth/auth.service.ts
+++ b/interfaces/IBF-dashboard/src/app/auth/auth.service.ts
@@ -172,9 +172,9 @@ export class AuthService {
     console.error('AuthService error: ', error);
   };
 
-  public logout() {
+  public logout(redirectUrl = '/login') {
     this.jwtService.destroyToken();
     this.authSubject.next(null);
-    void this.router.navigate(['/login']);
+    void this.router.navigate([redirectUrl]);
   }
 }

--- a/interfaces/IBF-dashboard/src/app/auth/auth.service.ts
+++ b/interfaces/IBF-dashboard/src/app/auth/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { BehaviorSubject, Observable, tap } from 'rxjs';
+import { ToastController } from '@ionic/angular';
+import { BehaviorSubject, catchError, EMPTY, Observable, tap } from 'rxjs';
 import { User } from 'src/app/models/user/user.model';
 import { UserRole } from 'src/app/models/user/user-role.enum';
 import { ApiService } from 'src/app/services/api.service';
@@ -8,6 +9,7 @@ import { JwtService } from 'src/app/services/jwt.service';
 import { UserService } from 'src/app/services/user.service';
 import { LoginRequest, LoginResponse, UserResponse } from 'src/app/types/api';
 
+const HTTP_STATUS_MESSAGE_MAP = { 401: 'Email and/or password unknown' };
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   public redirectUrl: string;
@@ -18,6 +20,7 @@ export class AuthService {
     private userService: UserService,
     private jwtService: JwtService,
     private router: Router,
+    private toastController: ToastController,
   ) {
     const user = this.getUserFromToken();
 
@@ -79,8 +82,30 @@ export class AuthService {
     };
   }
 
-  public login(loginRequest: LoginRequest) {
-    return this.apiService.login(loginRequest).pipe(
+  public login(email: string, password: string): Observable<UserResponse> {
+    return this.apiService.login(email, password).pipe(
+      tap(this.onLoginResponse),
+      catchError((err) => {
+        void this.onLoginError(err);
+
+        return EMPTY;
+      }),
+    );
+  }
+
+  public changePassword(password: string): Observable<User> {
+    return this.apiService.changePassword(password).pipe(
+      tap(this.onPasswordChanged),
+      catchError((err) => {
+        void this.onChangePasswordError(err);
+
+        return EMPTY;
+      }),
+    );
+  }
+
+  public backdoor(loginRequest: LoginRequest) {
+    return this.apiService.backdoor(loginRequest).pipe(
       tap((loginResponse: LoginResponse) => {
         if ('user' in loginResponse) {
           this.onLoginResponse(loginResponse);
@@ -112,6 +137,39 @@ export class AuthService {
     }
 
     void this.router.navigate(['/']);
+  };
+
+  private onLoginError = async ({ error }) => {
+    const message =
+      HTTP_STATUS_MESSAGE_MAP[error?.statusCode] || error?.message;
+    const toast = await this.toastController.create({
+      message: `Authentication Failed: ${message}`,
+      duration: 5000,
+    });
+
+    void toast.present();
+    console.error('AuthService error: ', error);
+  };
+
+  private onPasswordChanged = async () => {
+    const toast = await this.toastController.create({
+      message: 'Password changed successfully',
+      duration: 5000,
+    });
+
+    void toast.present();
+  };
+
+  private onChangePasswordError = async (error) => {
+    const message =
+      HTTP_STATUS_MESSAGE_MAP[error?.statusCode] || error?.message;
+    const toast = await this.toastController.create({
+      message: `Authentication Failed: ${message}`,
+      duration: 5000,
+    });
+
+    void toast.present();
+    console.error('AuthService error: ', error);
   };
 
   public logout() {

--- a/interfaces/IBF-dashboard/src/app/components/backdoor-form/backdoor-form.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/backdoor-form/backdoor-form.component.html
@@ -1,0 +1,105 @@
+<form #loginForm="ngForm" (ngSubmit)="onSubmit()" class="login-form">
+  <input
+    type="submit"
+    hidden
+    [disabled]="!loginForm.form.valid"
+  /><!-- Include hidden submit-button to enable "enter"-key to trigger ngSubmit -->
+
+  <ion-item>
+    <ion-label position="stacked">{{
+      'backdoor-page.enter-email' | translate
+    }}</ion-label>
+    <ion-input
+      #emailInput
+      [ngModel]="model.email"
+      (ngModelChange)="onEmailChange($event)"
+      email
+      name="email"
+      type="email"
+      required
+      inputmode="email"
+      pattern=".+@.+\.[a-z]+"
+      autocomplete="email"
+      [disabled]="formState === 'code'"
+      [autofocus]="formState === 'email'"
+      data-testid="input-email"
+    ></ion-input>
+  </ion-item>
+  @if (formState === 'code') {
+    <ion-item lines="none" class="my-4">
+      <div class="flex w-full flex-col items-center justify-evenly sm:flex-row">
+        <ion-button
+          fill="clear"
+          color="ibf-grey"
+          (click)="onReenterEmail()"
+          data-test="reenter-email-button"
+          >{{ 'backdoor-page.reenter-email' | translate }}</ion-button
+        >
+        <ion-button
+          fill="clear"
+          color="ibf-grey"
+          (click)="onSubmit(true)"
+          data-test="resend-code-button"
+          [disabled]="resendCodeDisabled"
+          >{{ 'backdoor-page.resend-code' | translate }}</ion-button
+        >
+      </div>
+    </ion-item>
+  }
+  <ion-item lines="none" class="items-center">
+    <ion-label
+      position="stacked"
+      class="text-center"
+      [color]="error ? 'danger' : 'ibf-no-alert-primary'"
+      [class.wiggle]="error"
+      >{{ message || '\u00A0' }}</ion-label
+    >
+    @if (formState === 'code') {
+      <ion-input
+        #codeInput
+        type="text"
+        name="code"
+        inputmode="numeric"
+        pattern="[0-9]*"
+        maxlength="6"
+        class="pointer-events-none absolute opacity-0"
+        autocomplete="one-time-code"
+        [ngModel]="model.code"
+        (ngModelChange)="onCodeChange($event)"
+        autofocus
+        data-testid="input-code"
+      />
+      <div
+        class="my-2 flex space-x-2 sm:space-x-4"
+        (click)="codeInput.setFocus()"
+      >
+        <span
+          *ngFor="let digit of codeDisplay; let i = index"
+          class="flex h-9 w-7 items-center justify-center rounded border border-gray-300 bg-white text-xl sm:h-12 sm:w-10"
+          [class.ring-2]="model.code?.length === i || (i === 0 && !model.code)"
+          [class.ring-blue-500]="
+            model.code?.length === i || (i === 0 && !model.code)
+          "
+          >{{ digit }}</span
+        >
+      </div>
+    } @else {
+      <ion-button
+        type="submit"
+        size="default"
+        shape="round"
+        color="fiveten-navy-900"
+        data-test="login-button"
+        class="w-full"
+        [disabled]="!loginForm.form.valid"
+        data-testid="button-login"
+        >{{ 'backdoor-page.title' | translate }}</ion-button
+      >
+    }
+  </ion-item>
+  <ion-item lines="none" class="mt-4">
+    <app-quick-links
+      class="flex w-full flex-col items-center justify-evenly sm:flex-row"
+    ></app-quick-links>
+  </ion-item>
+</form>

--- a/interfaces/IBF-dashboard/src/app/components/backdoor-form/backdoor-form.component.scss
+++ b/interfaces/IBF-dashboard/src/app/components/backdoor-form/backdoor-form.component.scss
@@ -1,0 +1,12 @@
+ion-item {
+  --background-focused: transparent;
+}
+
+ion-input {
+  border: none;
+  background: transparent;
+
+  ::ng-deep .native-input {
+    box-shadow: none;
+  }
+}

--- a/interfaces/IBF-dashboard/src/app/components/backdoor-form/backdoor-form.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/backdoor-form/backdoor-form.component.spec.ts
@@ -1,0 +1,551 @@
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { IonicModule } from '@ionic/angular';
+import { provideIonicAngular } from '@ionic/angular/standalone';
+import { TranslateModule } from '@ngx-translate/core';
+import { of, throwError } from 'rxjs';
+import { AnalyticsService } from 'src/app/analytics/analytics.service';
+import { AuthService } from 'src/app/auth/auth.service';
+import { BackdoorFormComponent } from 'src/app/components/backdoor-form/backdoor-form.component';
+
+describe('BackdoorFormComponent', () => {
+  let component: BackdoorFormComponent;
+  let fixture: ComponentFixture<BackdoorFormComponent>;
+  let authService: jasmine.SpyObj<AuthService>;
+  let analyticsService: jasmine.SpyObj<AnalyticsService>;
+  let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(async () => {
+    authService = jasmine.createSpyObj<AuthService>('AuthService', ['login']);
+
+    analyticsService = jasmine.createSpyObj<AnalyticsService>(
+      'AnalyticsService',
+      ['logEvent'],
+    );
+
+    activatedRoute = jasmine.createSpyObj<ActivatedRoute>(
+      'ActivatedRoute',
+      [],
+      { queryParams: of({}) },
+    );
+
+    router = jasmine.createSpyObj<Router>('Router', ['navigate']);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        IonicModule,
+        RouterModule.forRoot([]),
+        TranslateModule.forRoot(),
+        FormsModule,
+      ],
+      declarations: [BackdoorFormComponent],
+      providers: [
+        provideIonicAngular(),
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: authService },
+        { provide: AnalyticsService, useValue: analyticsService },
+        { provide: ActivatedRoute, useValue: activatedRoute },
+        { provide: Router, useValue: router },
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BackdoorFormComponent);
+
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+
+    expect(component.model.email).toBe('');
+
+    expect(component.model.code).toBe('');
+  });
+
+  it('should update model.email on onEmailChange', () => {
+    component.error = true;
+
+    component.message = 'Something went wrong';
+
+    component.onEmailChange('test');
+
+    expect(component.model.email).toBe('test');
+  });
+
+  it('should clear message on onEmailChange', () => {
+    component.message = 'Something went wrong';
+
+    component.onEmailChange('test');
+
+    expect(component.message).toBe('');
+  });
+
+  it('should clear error on onEmailChange', () => {
+    component.error = true;
+
+    component.onEmailChange('test');
+
+    expect(component.error).toBeFalse();
+  });
+
+  it('should update model.code on onCodeChange', () => {
+    component.onCodeChange('510');
+
+    expect(component.model.code).toBe('510');
+  });
+
+  it('should update codeDisplay on onCodeChange', () => {
+    component.onCodeChange('510');
+
+    expect(component.codeDisplay[0]).toBe('5');
+
+    expect(component.codeDisplay[1]).toBe('1');
+
+    expect(component.codeDisplay[2]).toBe('0');
+
+    expect(component.codeDisplay.slice(3)).toEqual(['', '', '']);
+  });
+
+  it('should not clear message on onCodeChange', () => {
+    component.message = 'Something went wrong';
+
+    component.onCodeChange('510');
+
+    expect(component.message).toBe('Something went wrong');
+  });
+
+  it('should clear error on onCodeChange', () => {
+    component.error = true;
+
+    component.onCodeChange('510');
+
+    expect(component.error).toBeFalse();
+  });
+
+  it('should call onSubmit on onCodeChange', () => {
+    spyOn(component, 'onSubmit');
+
+    component.onCodeChange('510510');
+
+    expect(component.onSubmit).toHaveBeenCalledWith();
+  });
+
+  it('should call authService.login with email on submit', () => {
+    authService.backdoor.and.returnValue(of({ message: 'Code sent' }));
+
+    component.model.email = 'test@example.com';
+
+    component.onSubmit();
+
+    const loginRequest = { email: 'test@example.com' };
+
+    expect(authService.backdoor).toHaveBeenCalledWith(loginRequest);
+  });
+
+  it('should normalize email on submit', () => {
+    authService.backdoor.and.returnValue(of({ message: 'Code sent' }));
+
+    component.model.email = ' TEST@EXAMPLE.COM';
+
+    component.onSubmit();
+
+    const loginRequest = { email: 'test@example.com' };
+
+    expect(authService.backdoor).toHaveBeenCalledWith(loginRequest);
+  });
+
+  it('should normalize code to 6 digits on submit', () => {
+    authService.backdoor.and.returnValue(of({ message: 'Code sent' }));
+
+    component.model.email = 'test@example.com';
+
+    component.model.code = '510510 ';
+
+    component.onSubmit();
+
+    const loginRequest = { email: 'test@example.com', code: 510510 };
+
+    expect(authService.backdoor).toHaveBeenCalledWith(loginRequest);
+  });
+
+  it('should normalize code to null on submit', () => {
+    authService.backdoor.and.returnValue(of({ message: 'Code sent' }));
+
+    component.model.email = 'test@example.com';
+
+    component.model.code = '51051';
+
+    component.onSubmit();
+
+    const loginRequest = { email: 'test@example.com' };
+
+    expect(authService.backdoor).toHaveBeenCalledWith(loginRequest);
+  });
+
+  it('should set form state to code and set message on login with email', () => {
+    authService.backdoor.and.returnValue(of({ message: 'Code sent' }));
+
+    spyOn(component.loginForm, 'resetForm').and.callThrough();
+
+    component.model.email = 'test@example.com';
+
+    component.formState = 'email';
+
+    component.onSubmit();
+
+    expect(component.model.email).toBe('test@example.com');
+
+    expect(component.formState).toBe('code');
+
+    expect(component.message).toBe('Code sent');
+
+    expect(component.error).toBeFalse();
+
+    expect(component.loginForm.resetForm).not.toHaveBeenCalledWith();
+  });
+
+  it('should set form state to email and clear message on login with email and code', () => {
+    authService.backdoor.and.returnValue(of({ message: 'Code sent' }));
+
+    spyOn(component.loginForm, 'resetForm').and.callThrough();
+
+    component.model.email = 'test@example.com';
+
+    component.model.code = '510510';
+
+    component.formState = 'code';
+
+    component.onSubmit();
+
+    expect(component.model.email).toBeNull();
+
+    expect(component.model.code).toBe('');
+
+    expect(component.formState).toBe('email');
+
+    expect(component.message).toBe('');
+
+    expect(component.error).toBeFalse();
+
+    expect(component.loginForm.resetForm).toHaveBeenCalledWith();
+  });
+
+  it('should set form state to code and set message on resend code', () => {
+    authService.backdoor.and.returnValue(of({ message: 'Code sent' }));
+
+    spyOn(component.loginForm, 'resetForm').and.callThrough();
+
+    component.model.email = 'test@example.com';
+
+    component.onSubmit(true);
+
+    expect(component.model.email).toBe('test@example.com');
+
+    expect(component.formState).toBe('code');
+
+    expect(component.message).toBe('Code sent');
+
+    expect(component.error).toBeFalse();
+
+    expect(component.loginForm.resetForm).not.toHaveBeenCalledWith();
+  });
+
+  it('should show unknown message on login with email error', () => {
+    authService.backdoor.and.returnValue(
+      throwError(() => ({ error: { message: null } })),
+    );
+
+    component.formState = 'email';
+
+    component.onSubmit();
+
+    expect(component.message).toBe('common.error.unknown');
+  });
+
+  it('should show returned message on login with email error', () => {
+    authService.backdoor.and.returnValue(
+      throwError(() => ({ error: { message: 'Invalid' } })),
+    );
+
+    component.formState = 'email';
+
+    component.onSubmit();
+
+    expect(component.message).toBe('Invalid');
+  });
+
+  it('should set error on login with email error', () => {
+    authService.backdoor.and.returnValue(
+      throwError(() => ({ error: { message: null } })),
+    );
+
+    component.formState = 'email';
+
+    component.onSubmit();
+
+    expect(component.error).toBeTrue();
+  });
+
+  it('should show unknown message on login with email and code error', () => {
+    authService.backdoor.and.returnValue(
+      throwError(() => ({ error: { message: null } })),
+    );
+
+    component.formState = 'code';
+
+    component.onSubmit();
+
+    expect(component.message).toBe('common.error.unknown');
+  });
+
+  it('should show returned message on login with email and code error', () => {
+    authService.backdoor.and.returnValue(
+      throwError(() => ({ error: { message: 'Invalid' } })),
+    );
+
+    component.formState = 'code';
+
+    component.onSubmit();
+
+    expect(component.message).toBe('Invalid');
+  });
+
+  it('should set error on login with email and code error', () => {
+    authService.backdoor.and.returnValue(
+      throwError(() => ({ error: { message: null } })),
+    );
+
+    component.formState = 'code';
+
+    component.onSubmit();
+
+    expect(component.error).toBeTrue();
+  });
+
+  it('should show unknown message on resend code error', () => {
+    authService.backdoor.and.returnValue(
+      throwError(() => ({ error: { message: null } })),
+    );
+
+    component.onSubmit(true);
+
+    expect(component.message).toBe('common.error.unknown');
+  });
+
+  it('should show returned message on resend code error', () => {
+    authService.backdoor.and.returnValue(
+      throwError(() => ({ error: { message: 'Invalid' } })),
+    );
+
+    component.onSubmit(true);
+
+    expect(component.message).toBe('Invalid');
+  });
+
+  it('should set form state to email and set message on login with email error', () => {
+    authService.backdoor.and.returnValue(
+      throwError(() => ({ error: { message: 'Something went wrong' } })),
+    );
+
+    spyOn(component.loginForm, 'resetForm').and.callThrough();
+
+    component.model.email = 'test@example.com';
+
+    component.formState = 'email';
+
+    component.onSubmit();
+
+    expect(component.model.email).toBeNull();
+
+    expect(component.formState).toBe('email');
+
+    expect(component.message).toBe('Something went wrong');
+
+    expect(component.error).toBeTrue();
+
+    expect(component.loginForm.resetForm).toHaveBeenCalledWith();
+  });
+
+  it('should set form state to code and set message on resend code error', () => {
+    authService.backdoor.and.returnValue(
+      throwError(() => ({ error: { message: 'Something went wrong' } })),
+    );
+
+    spyOn(component.loginForm, 'resetForm').and.callThrough();
+
+    component.model.email = 'test@example.com';
+
+    component.onSubmit(true);
+
+    expect(component.model.email).toBeNull();
+
+    expect(component.formState).toBe('email');
+
+    expect(component.message).toBe('Something went wrong');
+
+    expect(component.error).toBeTrue();
+
+    expect(component.loginForm.resetForm).toHaveBeenCalledWith();
+  });
+
+  it('should set form state to email and clear message on login with email and code error', () => {
+    authService.backdoor.and.returnValue(
+      throwError(() => ({ error: { message: 'Failed to login' } })),
+    );
+
+    spyOn(component.loginForm, 'resetForm').and.callThrough();
+
+    component.model.email = 'test@example.com';
+
+    component.model.code = '510510';
+
+    component.formState = 'code';
+
+    component.onSubmit();
+
+    expect(component.model.email).toBe('test@example.com');
+
+    expect(component.model.code).toBe('');
+
+    expect(component.formState).toBe('code');
+
+    expect(component.message).toBe('Failed to login');
+
+    expect(component.error).toBeTrue();
+
+    expect(component.loginForm.resetForm).not.toHaveBeenCalledWith();
+  });
+
+  it('should reset form to email state on reenter email', () => {
+    spyOn(component.loginForm, 'resetForm').and.callThrough();
+
+    component.onReenterEmail();
+
+    expect(component.formState).toBe('email');
+
+    expect(component.model.email).toBeNull();
+
+    expect(component.model.code).toBe('');
+
+    expect(component.message).toBe('');
+
+    expect(component.error).toBeFalse();
+
+    expect(component.resendCodeDisabled).toBeFalse();
+
+    expect(component.loginForm.resetForm).toHaveBeenCalledWith();
+  });
+
+  it('should set model.email from query params and call onSubmit', () => {
+    Object.defineProperty(activatedRoute, 'queryParams', {
+      value: of({ email: 'test@example.com' }),
+    });
+
+    spyOn(component, 'onSubmit');
+
+    component.ngOnInit();
+
+    expect(component.model.email).toBe('test@example.com');
+
+    expect(component.model.code).toBe('');
+
+    expect(component.onSubmit).toHaveBeenCalledWith();
+
+    expect(router.navigate).toHaveBeenCalledWith([], {
+      queryParams: { email: null, code: null },
+      queryParamsHandling: 'merge',
+    });
+  });
+
+  it('should set model.email and model.code from query params and call onSubmit', () => {
+    Object.defineProperty(activatedRoute, 'queryParams', {
+      value: of({ email: 'test@example.com', code: '510510' }),
+    });
+
+    spyOn(component, 'onSubmit');
+
+    component.ngOnInit();
+
+    expect(component.model.email).toBe('test@example.com');
+
+    expect(component.model.code).toBe('510510');
+
+    expect(component.onSubmit).toHaveBeenCalledWith();
+
+    expect(router.navigate).toHaveBeenCalledWith([], {
+      queryParams: { email: null, code: null },
+      queryParamsHandling: 'merge',
+    });
+  });
+
+  it('should focus code input', fakeAsync(() => {
+    authService.backdoor.and.returnValue(of({ message: 'Code sent' }));
+
+    component.model.email = 'test@example.com';
+
+    component.formState = 'email';
+
+    component.onSubmit();
+
+    expect(component.model.email).toBe('test@example.com');
+
+    expect(component.formState).toBe('code');
+
+    expect(component.message).toBe('Code sent');
+
+    expect(component.error).toBeFalse();
+
+    fixture.detectChanges();
+
+    spyOn(component.codeInput, 'setFocus').and.callThrough();
+
+    tick();
+
+    expect(component.codeInput.setFocus).toHaveBeenCalledWith();
+  }));
+
+  it('should focus email input', fakeAsync(() => {
+    authService.backdoor.and.returnValue(of({ message: 'Code sent' }));
+
+    spyOn(component.emailInput, 'setFocus').and.callThrough();
+
+    component.model.email = 'test@example.com';
+
+    component.model.code = '510510';
+
+    component.formState = 'code';
+
+    component.onSubmit();
+
+    expect(component.model.email).toBeNull();
+
+    expect(component.model.code).toBe('');
+
+    expect(component.formState).toBe('email');
+
+    expect(component.message).toBe('');
+
+    expect(component.error).toBeFalse();
+
+    tick();
+
+    expect(component.emailInput.setFocus).toHaveBeenCalledWith();
+  }));
+});

--- a/interfaces/IBF-dashboard/src/app/components/backdoor-form/backdoor-form.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/backdoor-form/backdoor-form.component.spec.ts
@@ -29,7 +29,10 @@ describe('BackdoorFormComponent', () => {
   let router: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
-    authService = jasmine.createSpyObj<AuthService>('AuthService', ['login']);
+    authService = jasmine.createSpyObj<AuthService>('AuthService', [
+      'login',
+      'backdoor',
+    ]);
 
     analyticsService = jasmine.createSpyObj<AnalyticsService>(
       'AnalyticsService',

--- a/interfaces/IBF-dashboard/src/app/components/backdoor-form/backdoor-form.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/backdoor-form/backdoor-form.component.ts
@@ -1,0 +1,177 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { NgForm } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { IonInput } from '@ionic/angular';
+import { TranslateService } from '@ngx-translate/core';
+import {
+  AnalyticsEvent,
+  AnalyticsPage,
+} from 'src/app/analytics/analytics.enum';
+import { AnalyticsService } from 'src/app/analytics/analytics.service';
+import { AuthService } from 'src/app/auth/auth.service';
+import { LoginRequest, MessageResponse } from 'src/app/types/api';
+
+@Component({
+  selector: 'app-backdoor-form',
+  templateUrl: './backdoor-form.component.html',
+  styleUrls: ['./backdoor-form.component.scss'],
+  standalone: false,
+})
+export class BackdoorFormComponent implements OnInit {
+  @ViewChild('loginForm')
+  public loginForm: NgForm;
+
+  @ViewChild('emailInput', { static: false })
+  public emailInput: IonInput;
+
+  @ViewChild('codeInput', { static: false })
+  public codeInput: IonInput;
+
+  public formState: 'code' | 'email' = 'email';
+  public model = { email: '', code: '' };
+  public resendCodeDisabled = false;
+  public codeDisplay: string[] = ['', '', '', '', '', ''];
+  public message = '';
+  public error = false;
+
+  constructor(
+    private authService: AuthService,
+    private analyticsService: AnalyticsService,
+    private translateService: TranslateService,
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {}
+
+  ngOnInit() {
+    this.route.queryParams.subscribe((params) => {
+      if (params['email']) {
+        this.model.email = String(params['email']);
+      }
+
+      if (params['code']) {
+        this.model.code = String(params['code']);
+      }
+
+      if (params['email']) {
+        this.onSubmit();
+      }
+    });
+
+    void this.router.navigate([], {
+      queryParams: { email: null, code: null },
+      queryParamsHandling: 'merge',
+    });
+  }
+
+  public onCodeChange(value: string) {
+    this.error = false;
+    this.model.code = value?.replace(/\D/g, '').slice(0, 6);
+
+    this.codeDisplay = this.model.code
+      ?.split('')
+      .concat(Array(6 - this.model.code.length).fill(''));
+
+    if (this.model.code?.length === 6) {
+      this.onSubmit();
+    }
+  }
+
+  private normalizeEmail(email: string) {
+    return email.trim().toLowerCase();
+  }
+
+  private normalizeCode(code: string) {
+    const trimmedCode = code.trim();
+
+    if (trimmedCode.length === 6) {
+      return Number(trimmedCode);
+    }
+
+    return null;
+  }
+
+  public onEmailChange(value: string) {
+    this.error = false;
+    this.message = '';
+    this.model.email = value;
+  }
+
+  public onSubmit(resendCode = false) {
+    const email = this.normalizeEmail(this.model.email);
+    const code = this.normalizeCode(this.model.code);
+
+    this.resendCodeDisabled = true;
+
+    const loginRequest: LoginRequest = { email };
+
+    if (code) {
+      loginRequest.code = code;
+    }
+
+    this.authService.backdoor(loginRequest).subscribe({
+      next: ({ message }: MessageResponse) => {
+        if (this.formState === 'email' || resendCode) {
+          this.resetForm('code', message);
+        } else {
+          this.resetForm('email');
+        }
+      },
+      error: ({ error: { message } }: { error: MessageResponse }) => {
+        message =
+          message ??
+          String(this.translateService.instant('common.error.unknown'));
+        if (this.formState === 'email' || resendCode) {
+          this.resetForm('email', message, true);
+        } else {
+          this.resetForm('code', message, true);
+        }
+      },
+    });
+
+    let analyticsEvent = AnalyticsEvent.loginCode;
+
+    if (resendCode) {
+      analyticsEvent = AnalyticsEvent.loginResend;
+    } else if (this.formState === 'email') {
+      analyticsEvent = AnalyticsEvent.loginEmail;
+    }
+
+    this.analyticsService.logEvent(analyticsEvent, {
+      page: AnalyticsPage.login,
+      component: this.constructor.name,
+    });
+  }
+
+  public onReenterEmail() {
+    this.resetForm('email');
+
+    this.analyticsService.logEvent(AnalyticsEvent.loginReenter, {
+      page: AnalyticsPage.login,
+      component: this.constructor.name,
+    });
+  }
+
+  private resetForm(
+    formState: 'code' | 'email' = 'email',
+    message = '',
+    error = false,
+  ) {
+    if (formState === 'email') {
+      this.loginForm.resetForm();
+    }
+    this.formState = formState;
+    this.model.code = '';
+    this.codeDisplay = ['', '', '', '', '', ''];
+    this.message = message;
+    this.error = error;
+    this.resendCodeDisabled = false;
+
+    setTimeout(() => {
+      if (formState === 'email') {
+        void this.emailInput?.setFocus();
+      } else {
+        void this.codeInput?.setFocus();
+      }
+    });
+  }
+}

--- a/interfaces/IBF-dashboard/src/app/components/change-password-popover/change-password-popover.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/change-password-popover/change-password-popover.component.html
@@ -1,0 +1,71 @@
+<ion-card class="popover-window-card">
+  <ion-card-header color="fiveten-navy-900">
+    <ion-icon
+      name="close-circle"
+      size="large"
+      (click)="closePopover()"
+      class="popover-close-button"
+    ></ion-icon>
+    <ion-card-title>{{
+      'user-state.password-change' | translate
+    }}</ion-card-title>
+  </ion-card-header>
+  <ion-card-content class="ion-padding-top ion-text-center">
+    <form
+      #changePasswordForm="ngForm"
+      (ngSubmit)="onSubmit()"
+      class="change-password-form"
+    >
+      <ion-item>
+        <ion-label position="stacked">{{
+          'user-state.password-new' | translate
+        }}</ion-label>
+        <ion-input
+          [ngModel]="model.newPassword"
+          (ngModelChange)="model.newPassword = $event"
+          name="new-password"
+          type="password"
+          required
+          autocomplete="new-password"
+          minlength="4"
+          clearInput="true"
+          clearOnEdit="false"
+          (ionChange)="onChange()"
+        ></ion-input>
+      </ion-item>
+      <ion-item>
+        <ion-label position="stacked">{{
+          'user-state.password-confirm' | translate
+        }}</ion-label>
+        <ion-input
+          [ngModel]="model.confirmPassword"
+          (ngModelChange)="model.confirmPassword = $event"
+          name="confirm-password"
+          type="password"
+          required
+          autocomplete="new-password"
+          minlength="4"
+          clearInput="true"
+          clearOnEdit="false"
+          (ionChange)="onChange()"
+        ></ion-input>
+      </ion-item>
+      <div class="validation-message ion-margin-top">
+        @if (showDifferentPasswordMessage) {
+          <ion-note color="danger">
+            <small>
+              <strong>{{ 'user-state.password-error' | translate }}</strong>
+            </small>
+          </ion-note>
+        }
+      </div>
+      <ion-button
+        type="submit"
+        shape="round"
+        color="fiveten-navy-900"
+        [disabled]="!changePasswordForm.form.valid"
+        >{{ 'user-state.password-change' | translate }}</ion-button
+      >
+    </form>
+  </ion-card-content>
+</ion-card>

--- a/interfaces/IBF-dashboard/src/app/components/change-password-popover/change-password-popover.component.scss
+++ b/interfaces/IBF-dashboard/src/app/components/change-password-popover/change-password-popover.component.scss
@@ -1,0 +1,20 @@
+.validation-message {
+  min-height: 36px;
+}
+
+.change-password-form {
+  width: 100%;
+}
+
+ion-input {
+  border: none;
+  background: transparent;
+
+  ::ng-deep .native-input {
+    box-shadow: none;
+  }
+}
+
+.popover-window-card {
+  border-color: var(--ion-color-fiveten-navy-900);
+}

--- a/interfaces/IBF-dashboard/src/app/components/change-password-popover/change-password-popover.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/change-password-popover/change-password-popover.component.spec.ts
@@ -1,0 +1,46 @@
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { IonicModule } from '@ionic/angular';
+import { TranslateModule } from '@ngx-translate/core';
+import { AuthService } from 'src/app/auth/auth.service';
+import { ChangePasswordPopoverComponent } from 'src/app/components/change-password-popover/change-password-popover.component';
+
+describe('ChangePasswordPopoverComponent', () => {
+  let component: ChangePasswordPopoverComponent;
+  let fixture: ComponentFixture<ChangePasswordPopoverComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ChangePasswordPopoverComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [
+        IonicModule.forRoot(),
+        FormsModule,
+        RouterModule.forRoot([]),
+        TranslateModule.forRoot(),
+      ],
+      providers: [
+        { provide: AuthService },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChangePasswordPopoverComponent);
+
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/interfaces/IBF-dashboard/src/app/components/change-password-popover/change-password-popover.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/change-password-popover/change-password-popover.component.ts
@@ -1,0 +1,53 @@
+import { Component, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy } from '@angular/core';
+import { NgForm } from '@angular/forms';
+import { PopoverController } from '@ionic/angular';
+import { AuthService } from 'src/app/auth/auth.service';
+
+@Component({
+  selector: 'app-change-password-popover',
+  templateUrl: './change-password-popover.component.html',
+  styleUrls: ['./change-password-popover.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class ChangePasswordPopoverComponent {
+  @ViewChild('changePasswordForm')
+  public changePasswordForm: NgForm;
+
+  public showDifferentPasswordMessage = false;
+
+  public model = { newPassword: '', confirmPassword: '' };
+
+  constructor(
+    private authService: AuthService,
+    private popoverController: PopoverController,
+  ) {}
+
+  public onSubmit() {
+    if (!this.changePasswordForm.form.valid) {
+      return;
+    }
+
+    if (this.model.confirmPassword !== this.model.newPassword) {
+      this.showDifferentPasswordMessage = true;
+
+      return;
+    }
+
+    this.authService.changePassword(this.model.newPassword).subscribe({
+      complete: () => {
+        this.changePasswordForm.resetForm();
+        void this.popoverController.dismiss();
+      },
+    });
+  }
+
+  onChange() {
+    this.showDifferentPasswordMessage = false;
+  }
+
+  public async closePopover(): Promise<void> {
+    await this.popoverController.dismiss();
+  }
+}

--- a/interfaces/IBF-dashboard/src/app/components/forgot-password-popover/forgot-password-popover.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/forgot-password-popover/forgot-password-popover.component.html
@@ -1,0 +1,19 @@
+<ion-card class="popover-window-card">
+  <ion-card-header color="ibf-primary">
+    <ion-icon
+      name="close-circle"
+      size="large"
+      (click)="closePopover()"
+      class="popover-close-button"
+    ></ion-icon>
+    <ion-card-title>Forgot password?</ion-card-title>
+  </ion-card-header>
+  <ion-card-content class="ion-padding-top ion-text-center">
+    <ion-item lines="none">
+      <span>
+        {{ 'login-page.forgot-password-message' | translate }}
+        <strong>{{ emailAddress }}</strong>
+      </span>
+    </ion-item>
+  </ion-card-content>
+</ion-card>

--- a/interfaces/IBF-dashboard/src/app/components/forgot-password-popover/forgot-password-popover.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/forgot-password-popover/forgot-password-popover.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+import { TranslateModule } from '@ngx-translate/core';
+import { ForgotPasswordPopoverComponent } from 'src/app/components/forgot-password-popover/forgot-password-popover.component';
+
+describe('ForgotPasswordPopoverComponent', () => {
+  let component: ForgotPasswordPopoverComponent;
+  let fixture: ComponentFixture<ForgotPasswordPopoverComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ForgotPasswordPopoverComponent],
+      imports: [IonicModule.forRoot(), TranslateModule.forRoot()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ForgotPasswordPopoverComponent);
+
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/interfaces/IBF-dashboard/src/app/components/forgot-password-popover/forgot-password-popover.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/forgot-password-popover/forgot-password-popover.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { PopoverController } from '@ionic/angular';
+import { environment } from 'src/environments/environment';
+
+@Component({
+  selector: 'app-forgot-password-popover',
+  templateUrl: './forgot-password-popover.component.html',
+  standalone: false,
+})
+export class ForgotPasswordPopoverComponent {
+  public emailAddress = environment.supportEmailAddress;
+
+  constructor(private popoverController: PopoverController) {}
+
+  public closePopover(): void {
+    this.popoverController.dismiss();
+  }
+}

--- a/interfaces/IBF-dashboard/src/app/components/login-form/login-form.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/login-form/login-form.component.html
@@ -7,99 +7,79 @@
 
   <ion-item>
     <ion-label position="stacked">{{
-      'login-page.enter-email' | translate
+      'login-page.email' | translate
     }}</ion-label>
     <ion-input
-      #emailInput
       [ngModel]="model.email"
-      (ngModelChange)="onEmailChange($event)"
-      email
+      (ngModelChange)="model.email = $event"
       name="email"
       type="email"
       required
       inputmode="email"
       pattern=".+@.+\.[a-z]+"
-      autocomplete="email"
-      [disabled]="formState === 'code'"
-      [autofocus]="formState === 'email'"
-      data-testid="input-email"
+      autocomplete="email username"
+      clearInput="true"
+      data-test="input-user"
     ></ion-input>
   </ion-item>
-  @if (formState === 'code') {
-    <ion-item lines="none" class="my-4">
-      <div class="flex w-full flex-col items-center justify-evenly sm:flex-row">
-        <ion-button
-          fill="clear"
-          color="ibf-grey"
-          (click)="onReenterEmail()"
-          data-test="reenter-email-button"
-          >{{ 'login-page.reenter-email' | translate }}</ion-button
-        >
-        <ion-button
-          fill="clear"
-          color="ibf-grey"
-          (click)="onSubmit(true)"
-          data-test="resend-code-button"
-          [disabled]="resendCodeDisabled"
-          >{{ 'login-page.resend-code' | translate }}</ion-button
-        >
-      </div>
-    </ion-item>
-  }
-  <ion-item lines="none" class="items-center">
-    <ion-label
-      position="stacked"
-      class="text-center"
-      [color]="error ? 'danger' : 'ibf-no-alert-primary'"
-      [class.wiggle]="error"
-      >{{ message || '\u00A0' }}</ion-label
-    >
-    @if (formState === 'code') {
+  <ion-item>
+    <ion-label position="stacked">{{
+      'login-page.password' | translate
+    }}</ion-label>
+    <div style="display: flex; width: 100%" class="ion-align-items-center">
       <ion-input
-        #codeInput
-        type="text"
-        name="code"
-        inputmode="numeric"
-        pattern="[0-9]*"
-        maxlength="6"
-        class="pointer-events-none absolute opacity-0"
-        autocomplete="one-time-code"
-        [ngModel]="model.code"
-        (ngModelChange)="onCodeChange($event)"
-        autofocus
-        data-testid="input-code"
-      />
-      <div
-        class="my-2 flex space-x-2 sm:space-x-4"
-        (click)="codeInput.setFocus()"
-      >
-        <span
-          *ngFor="let digit of codeDisplay; let i = index"
-          class="flex h-9 w-7 items-center justify-center rounded border border-gray-300 bg-white text-xl sm:h-12 sm:w-10"
-          [class.ring-2]="model.code?.length === i || (i === 0 && !model.code)"
-          [class.ring-blue-500]="
-            model.code?.length === i || (i === 0 && !model.code)
-          "
-          >{{ digit }}</span
-        >
-      </div>
-    } @else {
+        [ngModel]="model.password"
+        (ngModelChange)="model.password = $event"
+        name="password"
+        [type]="inputType"
+        required
+        autocomplete="current-password"
+        minlength="4"
+        clearInput="true"
+        clearOnEdit="false"
+        data-test="input-password"
+      ></ion-input>
       <ion-button
-        type="submit"
+        type="button"
+        fill="clear"
         size="default"
-        shape="round"
-        color="fiveten-navy-900"
-        data-test="login-button"
-        class="w-full"
-        [disabled]="!loginForm.form.valid"
-        data-testid="button-login"
-        >{{ 'login-page.title' | translate }}</ion-button
+        class="eye-button"
+        (click)="toggleInputType()"
+        [title]="isPassword() ? this.labelShow : this.labelHide"
+        [attr.aria-label]="isPassword() ? this.labelShow : this.labelHide"
       >
-    }
+        @if (isPassword()) {
+          <ion-icon slot="icon-only" name="eye" aria-hidden="true"></ion-icon>
+        } @else {
+          <ion-icon
+            slot="icon-only"
+            name="eye-off"
+            aria-hidden="true"
+          ></ion-icon>
+        }
+      </ion-button>
+    </div>
   </ion-item>
-  <ion-item lines="none" class="mt-4">
-    <app-quick-links
-      class="flex w-full flex-col items-center justify-evenly sm:flex-row"
-    ></app-quick-links>
-  </ion-item>
+
+  <ion-button
+    type="submit"
+    shape="round"
+    color="fiveten-navy-900"
+    expand="full"
+    data-test="login-button"
+    [disabled]="!loginForm.form.valid"
+    >{{ 'login-page.title' | translate }}</ion-button
+  >
+  <div
+    (click)="presentPopover()"
+    (keydown.enter)="presentPopover()"
+    tabindex="0"
+    class="ion-margin-vertical"
+  >
+    <ion-text
+      style="cursor: pointer; text-decoration: underline"
+      color="ibf-no-alert-primary"
+      >{{ 'login-page.forgot-password' | translate }}</ion-text
+    >
+  </div>
 </form>

--- a/interfaces/IBF-dashboard/src/app/components/login-form/login-form.component.scss
+++ b/interfaces/IBF-dashboard/src/app/components/login-form/login-form.component.scss
@@ -1,5 +1,5 @@
-ion-item {
-  --background-focused: transparent;
+ion-label[position='stacked'] {
+  --color: var(--ion-color-ibf-no-alert-primary);
 }
 
 ion-input {
@@ -9,4 +9,8 @@ ion-input {
   ::ng-deep .native-input {
     box-shadow: none;
   }
+}
+
+.eye-button {
+  --color: var(--ion-color-ibf-no-alert-primary);
 }

--- a/interfaces/IBF-dashboard/src/app/components/login-form/login-form.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/login-form/login-form.component.spec.ts
@@ -4,548 +4,148 @@ import {
 } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import {
-  ComponentFixture,
-  fakeAsync,
-  TestBed,
-  tick,
-} from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule, NgForm } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
-import { provideIonicAngular } from '@ionic/angular/standalone';
+import { PopoverController } from '@ionic/angular';
 import { TranslateModule } from '@ngx-translate/core';
-import { of, throwError } from 'rxjs';
-import { AnalyticsService } from 'src/app/analytics/analytics.service';
 import { AuthService } from 'src/app/auth/auth.service';
+import { ForgotPasswordPopoverComponent } from 'src/app/components/forgot-password-popover/forgot-password-popover.component';
 import { LoginFormComponent } from 'src/app/components/login-form/login-form.component';
 
 describe('LoginFormComponent', () => {
   let component: LoginFormComponent;
   let fixture: ComponentFixture<LoginFormComponent>;
-  let authService: jasmine.SpyObj<AuthService>;
-  let analyticsService: jasmine.SpyObj<AnalyticsService>;
-  let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
-  let router: jasmine.SpyObj<Router>;
+  let authService: AuthService;
+  let popoverController: PopoverController;
 
-  beforeEach(async () => {
-    authService = jasmine.createSpyObj<AuthService>('AuthService', ['login']);
-
-    analyticsService = jasmine.createSpyObj<AnalyticsService>(
-      'AnalyticsService',
-      ['logEvent'],
-    );
-
-    activatedRoute = jasmine.createSpyObj<ActivatedRoute>(
-      'ActivatedRoute',
-      [],
-      { queryParams: of({}) },
-    );
-
-    router = jasmine.createSpyObj<Router>('Router', ['navigate']);
-
-    await TestBed.configureTestingModule({
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [LoginFormComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [
         IonicModule,
+        FormsModule,
         RouterModule.forRoot([]),
         TranslateModule.forRoot(),
-        FormsModule,
       ],
-      declarations: [LoginFormComponent],
       providers: [
-        provideIonicAngular(),
+        {
+          provide: AuthService,
+          useValue: {
+            login: jasmine.createSpy('login').and.returnValue({
+              add: jasmine
+                .createSpy('add')
+                .and.callFake((callback: () => void) => {
+                  callback();
+                }),
+            }),
+          },
+        },
+        {
+          provide: PopoverController,
+          useValue: {
+            create: jasmine
+              .createSpy('create')
+              .and.resolveTo({ present: jasmine.createSpy('present') }),
+          },
+        },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
-        { provide: AuthService, useValue: authService },
-        { provide: AnalyticsService, useValue: analyticsService },
-        { provide: ActivatedRoute, useValue: activatedRoute },
-        { provide: Router, useValue: router },
       ],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LoginFormComponent);
 
     component = fixture.componentInstance;
 
+    authService = TestBed.inject(AuthService);
+
+    popoverController = TestBed.inject(PopoverController);
+
     fixture.detectChanges();
-  });
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
 
     expect(component.model.email).toBe('');
 
-    expect(component.model.code).toBe('');
+    expect(component.model.password).toBe('');
+
+    expect(component.inputType).toBe('password');
+
+    expect(component.labelShow).toBe('Show password');
+
+    expect(component.labelHide).toBe('Hide password');
   });
 
-  it('should update model.email on onEmailChange', () => {
-    component.error = true;
+  it('should call authService.login on onSubmit', () => {
+    component.model.email = 'dunant@redcross.nl';
 
-    component.message = 'Something went wrong';
-
-    component.onEmailChange('test');
-
-    expect(component.model.email).toBe('test');
-  });
-
-  it('should clear message on onEmailChange', () => {
-    component.message = 'Something went wrong';
-
-    component.onEmailChange('test');
-
-    expect(component.message).toBe('');
-  });
-
-  it('should clear error on onEmailChange', () => {
-    component.error = true;
-
-    component.onEmailChange('test');
-
-    expect(component.error).toBeFalse();
-  });
-
-  it('should update model.code on onCodeChange', () => {
-    component.onCodeChange('510');
-
-    expect(component.model.code).toBe('510');
-  });
-
-  it('should update codeDisplay on onCodeChange', () => {
-    component.onCodeChange('510');
-
-    expect(component.codeDisplay[0]).toBe('5');
-
-    expect(component.codeDisplay[1]).toBe('1');
-
-    expect(component.codeDisplay[2]).toBe('0');
-
-    expect(component.codeDisplay.slice(3)).toEqual(['', '', '']);
-  });
-
-  it('should not clear message on onCodeChange', () => {
-    component.message = 'Something went wrong';
-
-    component.onCodeChange('510');
-
-    expect(component.message).toBe('Something went wrong');
-  });
-
-  it('should clear error on onCodeChange', () => {
-    component.error = true;
-
-    component.onCodeChange('510');
-
-    expect(component.error).toBeFalse();
-  });
-
-  it('should call onSubmit on onCodeChange', () => {
-    spyOn(component, 'onSubmit');
-
-    component.onCodeChange('510510');
-
-    expect(component.onSubmit).toHaveBeenCalledWith();
-  });
-
-  it('should call authService.login with email on submit', () => {
-    authService.login.and.returnValue(of({ message: 'Code sent' }));
-
-    component.model.email = 'test@example.com';
+    component.model.password = 'password';
 
     component.onSubmit();
 
-    const loginRequest = { email: 'test@example.com' };
-
-    expect(authService.login).toHaveBeenCalledWith(loginRequest);
+    expect(authService.login).toHaveBeenCalledWith(
+      'dunant@redcross.nl',
+      'password',
+    );
   });
 
-  it('should normalize email on submit', () => {
-    authService.login.and.returnValue(of({ message: 'Code sent' }));
+  it('should reset form on successful login', () => {
+    component.loginForm = {
+      resetForm: jasmine.createSpy('resetForm') as () => void,
+    } as NgForm;
 
-    component.model.email = ' TEST@EXAMPLE.COM';
+    component.model.email = 'dunant@redcross.nl';
 
-    component.onSubmit();
-
-    const loginRequest = { email: 'test@example.com' };
-
-    expect(authService.login).toHaveBeenCalledWith(loginRequest);
-  });
-
-  it('should normalize code to 6 digits on submit', () => {
-    authService.login.and.returnValue(of({ message: 'Code sent' }));
-
-    component.model.email = 'test@example.com';
-
-    component.model.code = '510510 ';
+    component.model.password = 'password';
 
     component.onSubmit();
-
-    const loginRequest = { email: 'test@example.com', code: 510510 };
-
-    expect(authService.login).toHaveBeenCalledWith(loginRequest);
-  });
-
-  it('should normalize code to null on submit', () => {
-    authService.login.and.returnValue(of({ message: 'Code sent' }));
-
-    component.model.email = 'test@example.com';
-
-    component.model.code = '51051';
-
-    component.onSubmit();
-
-    const loginRequest = { email: 'test@example.com' };
-
-    expect(authService.login).toHaveBeenCalledWith(loginRequest);
-  });
-
-  it('should set form state to code and set message on login with email', () => {
-    authService.login.and.returnValue(of({ message: 'Code sent' }));
-
-    spyOn(component.loginForm, 'resetForm').and.callThrough();
-
-    component.model.email = 'test@example.com';
-
-    component.formState = 'email';
-
-    component.onSubmit();
-
-    expect(component.model.email).toBe('test@example.com');
-
-    expect(component.formState).toBe('code');
-
-    expect(component.message).toBe('Code sent');
-
-    expect(component.error).toBeFalse();
-
-    expect(component.loginForm.resetForm).not.toHaveBeenCalledWith();
-  });
-
-  it('should set form state to email and clear message on login with email and code', () => {
-    authService.login.and.returnValue(of({ message: 'Code sent' }));
-
-    spyOn(component.loginForm, 'resetForm').and.callThrough();
-
-    component.model.email = 'test@example.com';
-
-    component.model.code = '510510';
-
-    component.formState = 'code';
-
-    component.onSubmit();
-
-    expect(component.model.email).toBeNull();
-
-    expect(component.model.code).toBe('');
-
-    expect(component.formState).toBe('email');
-
-    expect(component.message).toBe('');
-
-    expect(component.error).toBeFalse();
 
     expect(component.loginForm.resetForm).toHaveBeenCalledWith();
   });
 
-  it('should set form state to code and set message on resend code', () => {
-    authService.login.and.returnValue(of({ message: 'Code sent' }));
+  it('should toggle inputType on toggleInputType', () => {
+    component.inputType = 'password';
 
-    spyOn(component.loginForm, 'resetForm').and.callThrough();
+    component.toggleInputType();
 
-    component.model.email = 'test@example.com';
+    expect(component.inputType).toBe('text');
 
-    component.onSubmit(true);
+    component.toggleInputType();
 
-    expect(component.model.email).toBe('test@example.com');
-
-    expect(component.formState).toBe('code');
-
-    expect(component.message).toBe('Code sent');
-
-    expect(component.error).toBeFalse();
-
-    expect(component.loginForm.resetForm).not.toHaveBeenCalledWith();
+    expect(component.inputType).toBe('password');
   });
 
-  it('should show unknown message on login with email error', () => {
-    authService.login.and.returnValue(
-      throwError(() => ({ error: { message: null } })),
-    );
+  it('should present popover on presentPopover', async () => {
+    await component.presentPopover();
+    const popoverOptions = {
+      component: ForgotPasswordPopoverComponent,
+      animated: true,
+      cssClass: 'ibf-popover ibf-popover-normal',
+      translucent: true,
+      showBackdrop: true,
+    };
 
-    component.formState = 'email';
+    expect(popoverController.create).toHaveBeenCalledWith(popoverOptions);
 
-    component.onSubmit();
+    const popover = await popoverController.create(popoverOptions);
 
-    expect(component.message).toBe('common.error.unknown');
+    expect(popover.present).toHaveBeenCalledWith();
   });
 
-  it('should show returned message on login with email error', () => {
-    authService.login.and.returnValue(
-      throwError(() => ({ error: { message: 'Invalid' } })),
-    );
+  it('should return true if inputType is password', () => {
+    component.inputType = 'password';
 
-    component.formState = 'email';
-
-    component.onSubmit();
-
-    expect(component.message).toBe('Invalid');
+    expect(component.isPassword()).toBeTrue();
   });
 
-  it('should set error on login with email error', () => {
-    authService.login.and.returnValue(
-      throwError(() => ({ error: { message: null } })),
-    );
+  it('should return false if inputType is not password', () => {
+    component.inputType = 'text';
 
-    component.formState = 'email';
-
-    component.onSubmit();
-
-    expect(component.error).toBeTrue();
+    expect(component.isPassword()).toBeFalse();
   });
-
-  it('should show unknown message on login with email and code error', () => {
-    authService.login.and.returnValue(
-      throwError(() => ({ error: { message: null } })),
-    );
-
-    component.formState = 'code';
-
-    component.onSubmit();
-
-    expect(component.message).toBe('common.error.unknown');
-  });
-
-  it('should show returned message on login with email and code error', () => {
-    authService.login.and.returnValue(
-      throwError(() => ({ error: { message: 'Invalid' } })),
-    );
-
-    component.formState = 'code';
-
-    component.onSubmit();
-
-    expect(component.message).toBe('Invalid');
-  });
-
-  it('should set error on login with email and code error', () => {
-    authService.login.and.returnValue(
-      throwError(() => ({ error: { message: null } })),
-    );
-
-    component.formState = 'code';
-
-    component.onSubmit();
-
-    expect(component.error).toBeTrue();
-  });
-
-  it('should show unknown message on resend code error', () => {
-    authService.login.and.returnValue(
-      throwError(() => ({ error: { message: null } })),
-    );
-
-    component.onSubmit(true);
-
-    expect(component.message).toBe('common.error.unknown');
-  });
-
-  it('should show returned message on resend code error', () => {
-    authService.login.and.returnValue(
-      throwError(() => ({ error: { message: 'Invalid' } })),
-    );
-
-    component.onSubmit(true);
-
-    expect(component.message).toBe('Invalid');
-  });
-
-  it('should set form state to email and set message on login with email error', () => {
-    authService.login.and.returnValue(
-      throwError(() => ({ error: { message: 'Something went wrong' } })),
-    );
-
-    spyOn(component.loginForm, 'resetForm').and.callThrough();
-
-    component.model.email = 'test@example.com';
-
-    component.formState = 'email';
-
-    component.onSubmit();
-
-    expect(component.model.email).toBeNull();
-
-    expect(component.formState).toBe('email');
-
-    expect(component.message).toBe('Something went wrong');
-
-    expect(component.error).toBeTrue();
-
-    expect(component.loginForm.resetForm).toHaveBeenCalledWith();
-  });
-
-  it('should set form state to code and set message on resend code error', () => {
-    authService.login.and.returnValue(
-      throwError(() => ({ error: { message: 'Something went wrong' } })),
-    );
-
-    spyOn(component.loginForm, 'resetForm').and.callThrough();
-
-    component.model.email = 'test@example.com';
-
-    component.onSubmit(true);
-
-    expect(component.model.email).toBeNull();
-
-    expect(component.formState).toBe('email');
-
-    expect(component.message).toBe('Something went wrong');
-
-    expect(component.error).toBeTrue();
-
-    expect(component.loginForm.resetForm).toHaveBeenCalledWith();
-  });
-
-  it('should set form state to email and clear message on login with email and code error', () => {
-    authService.login.and.returnValue(
-      throwError(() => ({ error: { message: 'Failed to login' } })),
-    );
-
-    spyOn(component.loginForm, 'resetForm').and.callThrough();
-
-    component.model.email = 'test@example.com';
-
-    component.model.code = '510510';
-
-    component.formState = 'code';
-
-    component.onSubmit();
-
-    expect(component.model.email).toBe('test@example.com');
-
-    expect(component.model.code).toBe('');
-
-    expect(component.formState).toBe('code');
-
-    expect(component.message).toBe('Failed to login');
-
-    expect(component.error).toBeTrue();
-
-    expect(component.loginForm.resetForm).not.toHaveBeenCalledWith();
-  });
-
-  it('should reset form to email state on reenter email', () => {
-    spyOn(component.loginForm, 'resetForm').and.callThrough();
-
-    component.onReenterEmail();
-
-    expect(component.formState).toBe('email');
-
-    expect(component.model.email).toBeNull();
-
-    expect(component.model.code).toBe('');
-
-    expect(component.message).toBe('');
-
-    expect(component.error).toBeFalse();
-
-    expect(component.resendCodeDisabled).toBeFalse();
-
-    expect(component.loginForm.resetForm).toHaveBeenCalledWith();
-  });
-
-  it('should set model.email from query params and call onSubmit', () => {
-    Object.defineProperty(activatedRoute, 'queryParams', {
-      value: of({ email: 'test@example.com' }),
-    });
-
-    spyOn(component, 'onSubmit');
-
-    component.ngOnInit();
-
-    expect(component.model.email).toBe('test@example.com');
-
-    expect(component.model.code).toBe('');
-
-    expect(component.onSubmit).toHaveBeenCalledWith();
-
-    expect(router.navigate).toHaveBeenCalledWith([], {
-      queryParams: { email: null, code: null },
-      queryParamsHandling: 'merge',
-    });
-  });
-
-  it('should set model.email and model.code from query params and call onSubmit', () => {
-    Object.defineProperty(activatedRoute, 'queryParams', {
-      value: of({ email: 'test@example.com', code: '510510' }),
-    });
-
-    spyOn(component, 'onSubmit');
-
-    component.ngOnInit();
-
-    expect(component.model.email).toBe('test@example.com');
-
-    expect(component.model.code).toBe('510510');
-
-    expect(component.onSubmit).toHaveBeenCalledWith();
-
-    expect(router.navigate).toHaveBeenCalledWith([], {
-      queryParams: { email: null, code: null },
-      queryParamsHandling: 'merge',
-    });
-  });
-
-  it('should focus code input', fakeAsync(() => {
-    authService.login.and.returnValue(of({ message: 'Code sent' }));
-
-    component.model.email = 'test@example.com';
-
-    component.formState = 'email';
-
-    component.onSubmit();
-
-    expect(component.model.email).toBe('test@example.com');
-
-    expect(component.formState).toBe('code');
-
-    expect(component.message).toBe('Code sent');
-
-    expect(component.error).toBeFalse();
-
-    fixture.detectChanges();
-
-    spyOn(component.codeInput, 'setFocus').and.callThrough();
-
-    tick();
-
-    expect(component.codeInput.setFocus).toHaveBeenCalledWith();
-  }));
-
-  it('should focus email input', fakeAsync(() => {
-    authService.login.and.returnValue(of({ message: 'Code sent' }));
-
-    spyOn(component.emailInput, 'setFocus').and.callThrough();
-
-    component.model.email = 'test@example.com';
-
-    component.model.code = '510510';
-
-    component.formState = 'code';
-
-    component.onSubmit();
-
-    expect(component.model.email).toBeNull();
-
-    expect(component.model.code).toBe('');
-
-    expect(component.formState).toBe('email');
-
-    expect(component.message).toBe('');
-
-    expect(component.error).toBeFalse();
-
-    tick();
-
-    expect(component.emailInput.setFocus).toHaveBeenCalledWith();
-  }));
 });

--- a/interfaces/IBF-dashboard/src/app/components/login-form/login-form.component.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/components/login-form/login-form.component.spec.ts
@@ -35,10 +35,10 @@ describe('LoginFormComponent', () => {
           provide: AuthService,
           useValue: {
             login: jasmine.createSpy('login').and.returnValue({
-              add: jasmine
-                .createSpy('add')
-                .and.callFake((callback: () => void) => {
-                  callback();
+              subscribe: jasmine
+                .createSpy('subscribe')
+                .and.callFake(({ complete }: { complete?: () => void }) => {
+                  complete?.();
                 }),
             }),
           },

--- a/interfaces/IBF-dashboard/src/app/components/login-form/login-form.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/login-form/login-form.component.ts
@@ -1,177 +1,59 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy } from '@angular/core';
 import { NgForm } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
-import { IonInput } from '@ionic/angular';
-import { TranslateService } from '@ngx-translate/core';
-import {
-  AnalyticsEvent,
-  AnalyticsPage,
-} from 'src/app/analytics/analytics.enum';
-import { AnalyticsService } from 'src/app/analytics/analytics.service';
+import { PopoverController } from '@ionic/angular';
 import { AuthService } from 'src/app/auth/auth.service';
-import { LoginRequest, MessageResponse } from 'src/app/types/api';
+import { ForgotPasswordPopoverComponent } from 'src/app/components/forgot-password-popover/forgot-password-popover.component';
 
 @Component({
   selector: 'app-login-form',
   templateUrl: './login-form.component.html',
   styleUrls: ['./login-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
-export class LoginFormComponent implements OnInit {
+export class LoginFormComponent {
   @ViewChild('loginForm')
   public loginForm: NgForm;
 
-  @ViewChild('emailInput', { static: false })
-  public emailInput: IonInput;
+  public model = { email: '', password: '' };
 
-  @ViewChild('codeInput', { static: false })
-  public codeInput: IonInput;
-
-  public formState: 'code' | 'email' = 'email';
-  public model = { email: '', code: '' };
-  public resendCodeDisabled = false;
-  public codeDisplay: string[] = ['', '', '', '', '', ''];
-  public message = '';
-  public error = false;
+  public inputType: 'password' | 'text' = 'password';
+  public labelShow = 'Show password';
+  public labelHide = 'Hide password';
 
   constructor(
     private authService: AuthService,
-    private analyticsService: AnalyticsService,
-    private translateService: TranslateService,
-    private route: ActivatedRoute,
-    private router: Router,
+    private popoverController: PopoverController,
   ) {}
 
-  ngOnInit() {
-    this.route.queryParams.subscribe((params) => {
-      if (params['email']) {
-        this.model.email = String(params['email']);
-      }
+  public onSubmit() {
+    this.authService
+      .login(this.model.email.toLowerCase(), this.model.password)
+      .subscribe({
+        complete: () => {
+          this.loginForm.resetForm();
+        },
+      });
+  }
 
-      if (params['code']) {
-        this.model.code = String(params['code']);
-      }
-
-      if (params['email']) {
-        this.onSubmit();
-      }
+  public async presentPopover(): Promise<void> {
+    const popover = await this.popoverController.create({
+      component: ForgotPasswordPopoverComponent,
+      animated: true,
+      cssClass: 'ibf-popover ibf-popover-normal',
+      translucent: true,
+      showBackdrop: true,
     });
 
-    void this.router.navigate([], {
-      queryParams: { email: null, code: null },
-      queryParamsHandling: 'merge',
-    });
+    await popover.present();
   }
 
-  public onCodeChange(value: string) {
-    this.error = false;
-    this.model.code = value?.replace(/\D/g, '').slice(0, 6);
-
-    this.codeDisplay = this.model.code
-      ?.split('')
-      .concat(Array(6 - this.model.code.length).fill(''));
-
-    if (this.model.code?.length === 6) {
-      this.onSubmit();
-    }
+  isPassword() {
+    return this.inputType === 'password';
   }
 
-  private normalizeEmail(email: string) {
-    return email.trim().toLowerCase();
-  }
-
-  private normalizeCode(code: string) {
-    const trimmedCode = code.trim();
-
-    if (trimmedCode.length === 6) {
-      return Number(trimmedCode);
-    }
-
-    return null;
-  }
-
-  public onEmailChange(value: string) {
-    this.error = false;
-    this.message = '';
-    this.model.email = value;
-  }
-
-  public onSubmit(resendCode = false) {
-    const email = this.normalizeEmail(this.model.email);
-    const code = this.normalizeCode(this.model.code);
-
-    this.resendCodeDisabled = true;
-
-    const loginRequest: LoginRequest = { email };
-
-    if (code) {
-      loginRequest.code = code;
-    }
-
-    this.authService.login(loginRequest).subscribe({
-      next: ({ message }: MessageResponse) => {
-        if (this.formState === 'email' || resendCode) {
-          this.resetForm('code', message);
-        } else {
-          this.resetForm('email');
-        }
-      },
-      error: ({ error: { message } }: { error: MessageResponse }) => {
-        message =
-          message ??
-          String(this.translateService.instant('common.error.unknown'));
-        if (this.formState === 'email' || resendCode) {
-          this.resetForm('email', message, true);
-        } else {
-          this.resetForm('code', message, true);
-        }
-      },
-    });
-
-    let analyticsEvent = AnalyticsEvent.loginCode;
-
-    if (resendCode) {
-      analyticsEvent = AnalyticsEvent.loginResend;
-    } else if (this.formState === 'email') {
-      analyticsEvent = AnalyticsEvent.loginEmail;
-    }
-
-    this.analyticsService.logEvent(analyticsEvent, {
-      page: AnalyticsPage.login,
-      component: this.constructor.name,
-    });
-  }
-
-  public onReenterEmail() {
-    this.resetForm('email');
-
-    this.analyticsService.logEvent(AnalyticsEvent.loginReenter, {
-      page: AnalyticsPage.login,
-      component: this.constructor.name,
-    });
-  }
-
-  private resetForm(
-    formState: 'code' | 'email' = 'email',
-    message = '',
-    error = false,
-  ) {
-    if (formState === 'email') {
-      this.loginForm.resetForm();
-    }
-    this.formState = formState;
-    this.model.code = '';
-    this.codeDisplay = ['', '', '', '', '', ''];
-    this.message = message;
-    this.error = error;
-    this.resendCodeDisabled = false;
-
-    setTimeout(() => {
-      if (formState === 'email') {
-        void this.emailInput?.setFocus();
-      } else {
-        void this.codeInput?.setFocus();
-      }
-    });
+  toggleInputType() {
+    this.inputType = this.isPassword() ? 'text' : 'password';
   }
 }

--- a/interfaces/IBF-dashboard/src/app/components/user-state-menu/user-state-menu.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/user-state-menu/user-state-menu.component.html
@@ -5,9 +5,14 @@
       <h3>{{ userName }}</h3>
     </ion-label>
   </ion-item>
-  <ion-item [button]="true" [detail]="false" routerLink="manage">{{
-    'user-state.manage' | translate
+  <ion-item [button]="true" [detail]="false" (click)="presentPopover()">{{
+    'user-state.password-change' | translate
   }}</ion-item>
+  <!--
+  <ion-item [button]="true" [detail]="false" routerLink="manage">{{
+      'user-state.manage' | translate
+    }}</ion-item>
+  -->
   <ion-item
     [button]="true"
     [detail]="false"

--- a/interfaces/IBF-dashboard/src/app/components/user-state-menu/user-state-menu.component.html
+++ b/interfaces/IBF-dashboard/src/app/components/user-state-menu/user-state-menu.component.html
@@ -9,6 +9,7 @@
     'user-state.password-change' | translate
   }}</ion-item>
   <!--
+  hide navigation to the manage pages until design approves the feature
   <ion-item [button]="true" [detail]="false" routerLink="manage">{{
       'user-state.manage' | translate
     }}</ion-item>

--- a/interfaces/IBF-dashboard/src/app/components/user-state-menu/user-state-menu.component.ts
+++ b/interfaces/IBF-dashboard/src/app/components/user-state-menu/user-state-menu.component.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
+import { PopoverController } from '@ionic/angular';
 import {
   AnalyticsEvent,
   AnalyticsPage,
 } from 'src/app/analytics/analytics.enum';
 import { AnalyticsService } from 'src/app/analytics/analytics.service';
 import { AuthService } from 'src/app/auth/auth.service';
+import { ChangePasswordPopoverComponent } from 'src/app/components/change-password-popover/change-password-popover.component';
 import { EventService } from 'src/app/services/event.service';
 import { LoaderService } from 'src/app/services/loader.service';
 
@@ -19,6 +21,7 @@ export class UserStateMenuComponent {
     private loaderService: LoaderService,
     private analyticsService: AnalyticsService,
     private eventService: EventService,
+    private popoverController: PopoverController,
   ) {}
 
   get userName() {
@@ -35,5 +38,17 @@ export class UserStateMenuComponent {
     this.loaderService.setLoader('logout', false);
     this.authService.logout();
     window.location.reload();
+  }
+
+  public async presentPopover() {
+    const popover = await this.popoverController.create({
+      component: ChangePasswordPopoverComponent,
+      animated: true,
+      cssClass: 'ibf-popover ibf-popover-normal',
+      translucent: true,
+      showBackdrop: true,
+    });
+
+    void popover.present();
   }
 }

--- a/interfaces/IBF-dashboard/src/app/pages/login/backdoor/backdoor.page.html
+++ b/interfaces/IBF-dashboard/src/app/pages/login/backdoor/backdoor.page.html
@@ -1,0 +1,33 @@
+<ion-header class="ion-no-border">
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-button href="/" [title]="'app-name' | translate">
+        <ion-icon name="apps" slot="icon-only"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+    <app-user-state></app-user-state>
+  </ion-toolbar>
+  <app-disclaimer-toolbar></app-disclaimer-toolbar>
+</ion-header>
+
+<ion-content
+  class="ion-align-items-center ion-justify-content-center ion-display-flex"
+>
+  <app-map class="absolute z-0 h-full w-full"></app-map>
+  <ion-card
+    class="ibf-login-card m-0 h-full w-full sm:bottom-[6%] sm:m-auto sm:h-auto sm:max-w-lg"
+    mode="ios"
+  >
+    <ion-card-header>
+      <ion-card-title
+        class="text-center"
+        color="ibf-grey"
+        data-testid="welcome-message"
+        >{{ 'backdoor-page.welcome' | translate }}</ion-card-title
+      >
+    </ion-card-header>
+    <ion-card-content>
+      <app-backdoor-form></app-backdoor-form>
+    </ion-card-content>
+  </ion-card>
+</ion-content>

--- a/interfaces/IBF-dashboard/src/app/pages/login/backdoor/backdoor.page.scss
+++ b/interfaces/IBF-dashboard/src/app/pages/login/backdoor/backdoor.page.scss
@@ -1,0 +1,3 @@
+ion-content::part(scroll) {
+  display: flex;
+}

--- a/interfaces/IBF-dashboard/src/app/pages/login/backdoor/backdoor.page.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/pages/login/backdoor/backdoor.page.spec.ts
@@ -1,0 +1,42 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+import { TranslateModule } from '@ngx-translate/core';
+import { addIcons } from 'ionicons';
+import { apps } from 'ionicons/icons';
+import { AnalyticsService } from 'src/app/analytics/analytics.service';
+import { BackdoorPage } from 'src/app/pages/login/backdoor/backdoor.page';
+
+describe('BackdoorPage', () => {
+  let component: BackdoorPage;
+  let fixture: ComponentFixture<BackdoorPage>;
+  let analyticsService: jasmine.SpyObj<AnalyticsService>;
+
+  beforeEach(waitForAsync(() => {
+    addIcons({ apps });
+
+    analyticsService = jasmine.createSpyObj<AnalyticsService>(
+      'AnalyticsService',
+      ['logPageView'],
+    );
+
+    analyticsService.logPageView.and.returnValue(null);
+
+    TestBed.configureTestingModule({
+      declarations: [BackdoorPage],
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [IonicModule, TranslateModule.forRoot()],
+      providers: [{ provide: AnalyticsService, useValue: analyticsService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BackdoorPage);
+
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/interfaces/IBF-dashboard/src/app/pages/login/backdoor/backdoor.page.ts
+++ b/interfaces/IBF-dashboard/src/app/pages/login/backdoor/backdoor.page.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { AnalyticsPage } from 'src/app/analytics/analytics.enum';
+import { AnalyticsService } from 'src/app/analytics/analytics.service';
+import { environment } from 'src/environments/environment';
+
+@Component({
+  selector: 'app-backdoor',
+  templateUrl: './backdoor.page.html',
+  styleUrls: ['./backdoor.page.scss'],
+  standalone: false,
+})
+export class BackdoorPage implements OnInit {
+  public version = environment.ibfSystemVersion;
+
+  constructor(private analyticsService: AnalyticsService) {}
+
+  ngOnInit() {
+    this.analyticsService.logPageView(AnalyticsPage.backdoor);
+  }
+}

--- a/interfaces/IBF-dashboard/src/app/pages/login/login-routing.module.ts
+++ b/interfaces/IBF-dashboard/src/app/pages/login/login-routing.module.ts
@@ -1,8 +1,12 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { BackdoorPage } from 'src/app/pages/login/backdoor/backdoor.page';
 import { LoginPage } from 'src/app/pages/login/login.page';
 
-const routes: Routes = [{ path: '', component: LoginPage }];
+const routes: Routes = [
+  { path: '', component: LoginPage },
+  { path: 'backdoor', component: BackdoorPage },
+];
 
 @NgModule({ imports: [RouterModule.forChild(routes)], exports: [RouterModule] })
 export class LoginPageRoutingModule {}

--- a/interfaces/IBF-dashboard/src/app/pages/login/login.module.ts
+++ b/interfaces/IBF-dashboard/src/app/pages/login/login.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
+import { BackdoorPage } from 'src/app/pages/login/backdoor/backdoor.page';
 import { LoginPage } from 'src/app/pages/login/login.page';
 import { LoginPageRoutingModule } from 'src/app/pages/login/login-routing.module';
 import { SharedModule } from 'src/app/shared.module';
@@ -14,6 +15,6 @@ import { SharedModule } from 'src/app/shared.module';
     SharedModule,
     LoginPageRoutingModule,
   ],
-  declarations: [LoginPage],
+  declarations: [LoginPage, BackdoorPage],
 })
 export class LoginPageModule {}

--- a/interfaces/IBF-dashboard/src/app/pages/login/login.page.html
+++ b/interfaces/IBF-dashboard/src/app/pages/login/login.page.html
@@ -6,28 +6,74 @@
       </ion-button>
     </ion-buttons>
     <app-user-state></app-user-state>
+    <ion-buttons slot="end">
+      <ion-button
+        href="https://github.com/rodekruis/IBF-system/releases/tag/{{
+          version
+        }}"
+        [title]="('common.version' | translate) + ' ' + version"
+        target="_blank"
+      >
+        {{ version }}
+      </ion-button>
+    </ion-buttons>
   </ion-toolbar>
   <app-disclaimer-toolbar></app-disclaimer-toolbar>
 </ion-header>
 
-<ion-content
-  class="ion-align-items-center ion-justify-content-center ion-display-flex"
->
-  <app-map class="absolute z-0 h-full w-full"></app-map>
-  <ion-card
-    class="ibf-login-card m-0 h-full w-full sm:bottom-[6%] sm:m-auto sm:h-auto sm:max-w-lg"
-    mode="ios"
-  >
-    <ion-card-header>
-      <ion-card-title
-        class="text-center"
-        color="ibf-grey"
-        data-testid="welcome-message"
-        >{{ 'login-page.welcome' | translate }}</ion-card-title
-      >
-    </ion-card-header>
-    <ion-card-content>
-      <app-login-form></app-login-form>
-    </ion-card-content>
-  </ion-card>
+<ion-content>
+  <ion-grid>
+    <ion-row class="ion-justify-content-center ion-align-items-center">
+      <ion-col size-xs="12" size-sm="11" size-md="9" size-lg="7" size-xl="6">
+        @for (disasterType of allDisasterTypes; track disasterType) {
+          <span data-test="disaster-Type" class="container">
+            <ion-icon
+              [src]="getIconByCountry(disasterType)"
+              slot="start"
+              class="disaster-type-icon"
+              [title]="disasterType"
+            >
+            </ion-icon>
+          </span>
+        }
+        <ion-card class="ibf-welcome-card" color="ibf-no-alert-primary">
+          <ion-icon
+            src="assets/icons/IBF_Impact_Based_Forecast_Logo_32x32.svg"
+          ></ion-icon>
+          <ion-card-header>
+            <ion-card-title
+              data-testid="login-welcome-message"
+              [translate]="'login-page.welcome'"
+            >
+            </ion-card-title>
+            <ion-card-subtitle [translate]="'login-page.instruction'">
+            </ion-card-subtitle>
+          </ion-card-header>
+          <ion-card-content>
+            <ion-button
+              (click)="presentPopover()"
+              expand="full"
+              shape="round"
+              color="fiveten-neutral-0"
+              size="small"
+            >
+              {{ 'ibf-guide-component.title' | translate }}
+            </ion-button>
+            <br />
+            <span [innerHtml]="'login-page.note' | translate"></span>
+          </ion-card-content>
+        </ion-card>
+        <ion-card class="ibf-login-card">
+          <ion-icon
+            name="person"
+            class="person"
+            color="ibf-no-alert-primary"
+          ></ion-icon>
+          <ion-card-content>
+            <app-login-form></app-login-form>
+          </ion-card-content>
+        </ion-card>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
 </ion-content>

--- a/interfaces/IBF-dashboard/src/app/pages/login/login.page.scss
+++ b/interfaces/IBF-dashboard/src/app/pages/login/login.page.scss
@@ -1,3 +1,64 @@
-ion-content::part(scroll) {
-  display: flex;
+ion-content {
+  --background: var(--ion-color-ibf-grey-light);
+
+  ion-grid {
+    min-height: 80vh;
+    display: flex;
+    flex-direction: column;
+
+    ion-row {
+      margin: auto 0;
+    }
+  }
+}
+
+.ibf-welcome-card {
+  overflow: visible;
+  margin-left: 64px;
+
+  ion-card-content {
+    ion-card-title {
+      cursor: pointer;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  ion-icon {
+    font-size: 48px;
+    position: absolute;
+    left: -50px;
+  }
+}
+
+.ibf-login-card {
+  overflow: visible;
+  margin-right: 64px;
+
+  ion-icon {
+    font-size: 48px;
+    background: var(--ion-color-ibf-no-alert-primary-contrast);
+    border-radius: 50%;
+    padding: 6px;
+    position: absolute;
+    right: -48px;
+
+    &.person {
+      font-size: 34px !important;
+    }
+  }
+}
+
+.container {
+  text-align: center;
+  margin-left: 20px;
+}
+
+.disaster-type-icon {
+  height: 32px;
+  width: 32px;
+  margin: 0px 5px 0px 5px;
+  padding-right: 10px;
 }

--- a/interfaces/IBF-dashboard/src/app/pages/login/login.page.spec.ts
+++ b/interfaces/IBF-dashboard/src/app/pages/login/login.page.spec.ts
@@ -1,11 +1,14 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
+import { PopoverController } from '@ionic/angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { addIcons } from 'ionicons';
 import { apps } from 'ionicons/icons';
+import { of } from 'rxjs';
 import { AnalyticsService } from 'src/app/analytics/analytics.service';
 import { LoginPage } from 'src/app/pages/login/login.page';
+import { CountryService } from 'src/app/services/country.service';
 
 describe('LoginPage', () => {
   let component: LoginPage;
@@ -26,7 +29,21 @@ describe('LoginPage', () => {
       declarations: [LoginPage],
       schemas: [NO_ERRORS_SCHEMA],
       imports: [IonicModule, TranslateModule.forRoot()],
-      providers: [{ provide: AnalyticsService, useValue: analyticsService }],
+      providers: [
+        { provide: AnalyticsService, useValue: analyticsService },
+        {
+          provide: PopoverController,
+          useValue: { create: jasmine.createSpy('create') },
+        },
+        {
+          provide: CountryService,
+          useValue: {
+            getCountries: jasmine
+              .createSpy('getCountries')
+              .and.returnValue(of([])),
+          },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LoginPage);

--- a/interfaces/IBF-dashboard/src/app/pages/login/login.page.ts
+++ b/interfaces/IBF-dashboard/src/app/pages/login/login.page.ts
@@ -1,6 +1,15 @@
 import { Component, OnInit } from '@angular/core';
-import { AnalyticsPage } from 'src/app/analytics/analytics.enum';
+import { PopoverController } from '@ionic/angular';
+import { Subscription } from 'rxjs';
+import {
+  AnalyticsEvent,
+  AnalyticsPage,
+} from 'src/app/analytics/analytics.enum';
 import { AnalyticsService } from 'src/app/analytics/analytics.service';
+import { IbfGuidePopoverComponent } from 'src/app/components/ibf-guide-popover/ibf-guide-popover.component';
+import { DISASTER_TYPES_SVG_MAP } from 'src/app/config';
+import { Country, DisasterType } from 'src/app/models/country.model';
+import { CountryService } from 'src/app/services/country.service';
 import { environment } from 'src/environments/environment';
 
 @Component({
@@ -10,11 +19,66 @@ import { environment } from 'src/environments/environment';
   standalone: false,
 })
 export class LoginPage implements OnInit {
-  public version = environment.ibfSystemVersion;
+  public version: string = environment.ibfSystemVersion;
+  public country: Country;
+  public countrySubscription: Subscription;
+  public envDisasterTypes: string[] = [];
+  public allDisasterTypes: string[] = [];
+  public disasterTypeMap = DISASTER_TYPES_SVG_MAP;
+  public environmentConfiguration = environment.configuration;
 
-  constructor(private analyticsService: AnalyticsService) {}
+  constructor(
+    private popoverController: PopoverController,
+    private analyticsService: AnalyticsService,
+    public countryService: CountryService,
+  ) {}
 
   ngOnInit() {
     this.analyticsService.logPageView(AnalyticsPage.login);
+    this.allDisasterTypes = Object.keys(DISASTER_TYPES_SVG_MAP);
+    this.countryService.getCountries().subscribe(this.onGetCountries);
+  }
+
+  public getIconByCountry = (disasterType: string) => {
+    if (this.envDisasterTypes?.includes(disasterType)) {
+      return this.disasterTypeMap[disasterType].selectedNonTriggered;
+    } else {
+      return this.disasterTypeMap[disasterType].disabled;
+    }
+  };
+
+  private onGetCountries = (countries: Country[]) => {
+    countries.forEach((country: Country) => {
+      country.disasterTypes.forEach((disasterType: DisasterType) => {
+        const isExist = this.envDisasterTypes.find(
+          (item) => item === disasterType.disasterType,
+        );
+
+        if (!isExist) {
+          this.envDisasterTypes.push(disasterType.disasterType);
+        }
+      });
+    });
+  };
+
+  async presentPopover(): Promise<void> {
+    const popover = await this.popoverController.create({
+      component: IbfGuidePopoverComponent,
+      componentProps: {
+        videoUrl: environment.ibfVideoGuideUrl,
+        pdfUrl: environment.ibfPdfGuideUrl,
+      },
+      animated: true,
+      cssClass: 'ibf-popover ibf-popover-large',
+      translucent: true,
+      showBackdrop: true,
+    });
+
+    this.analyticsService.logEvent(AnalyticsEvent.watchIbfGuide, {
+      page: AnalyticsPage.login,
+      component: this.constructor.name,
+    });
+
+    popover.present();
   }
 }

--- a/interfaces/IBF-dashboard/src/app/services/api.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/api.service.ts
@@ -172,10 +172,22 @@ export class ApiService {
   // API-endpoints:
   /////////////////////////////////////////////////////////////////////////////
 
-  login(loginRequest: LoginRequest) {
+  backdoor(loginRequest: LoginRequest) {
     this.log('ApiService : login()');
 
     return this.post('login', loginRequest, { anonymous: true });
+  }
+
+  login(email: string, password: string): Observable<{ user: User }> {
+    this.log('ApiService : login()');
+
+    return this.post('user/login', { email, password }, { anonymous: true });
+  }
+
+  changePassword(password: string): Observable<User> {
+    this.log('ApiService : changePassword()');
+
+    return this.post('user/change-password', { password });
   }
 
   getCountries(): Observable<Country[]> {

--- a/interfaces/IBF-dashboard/src/app/services/auth.interceptor.service.ts
+++ b/interfaces/IBF-dashboard/src/app/services/auth.interceptor.service.ts
@@ -49,7 +49,11 @@ export class AuthInterceptorService implements HttpInterceptor {
 
   private handleError(error: unknown): void {
     if (error instanceof HttpErrorResponse && error.status === 401) {
-      this.authService.logout();
+      const isBackdoorRequest =
+        error.url?.startsWith(`${environment.apiUrl}/login`) ?? false;
+      const redirectUrl = isBackdoorRequest ? '/login/backdoor' : '/login';
+
+      this.authService.logout(redirectUrl);
     }
   }
 }

--- a/interfaces/IBF-dashboard/src/app/shared.module.ts
+++ b/interfaces/IBF-dashboard/src/app/shared.module.ts
@@ -13,6 +13,8 @@ import { ActivationLogButtonComponent } from 'src/app/components/activation-log-
 import { AdminLevelComponent } from 'src/app/components/admin-level/admin-level.component';
 import { AggregatesComponent } from 'src/app/components/aggregates/aggregates.component';
 import { AreasOfFocusSummaryComponent } from 'src/app/components/areas-of-focus-summary/areas-of-focus-summary.component';
+import { BackdoorFormComponent } from 'src/app/components/backdoor-form/backdoor-form.component';
+import { ChangePasswordPopoverComponent } from 'src/app/components/change-password-popover/change-password-popover.component';
 import { ChatComponent } from 'src/app/components/chat/chat.component';
 import { CommunityNotificationPhotoPopupComponent } from 'src/app/components/community-notification-photo-popup/community-notification-photo-popup.component';
 import { CommunityNotificationPopupComponent } from 'src/app/components/community-notification-popup/community-notification-popup.component';
@@ -26,6 +28,7 @@ import { EventSpeechBubbleComponent } from 'src/app/components/event-speech-bubb
 import { EventSwitcherComponent } from 'src/app/components/event-switcher/event-switcher.component';
 import { ExportViewComponent } from 'src/app/components/export-view/export-view.component';
 import { ExportViewPopoverComponent } from 'src/app/components/export-view-popover/export-view-popover.component';
+import { ForgotPasswordPopoverComponent } from 'src/app/components/forgot-password-popover/forgot-password-popover.component';
 import { IbfGuideButtonComponent } from 'src/app/components/ibf-guide-button/ibf-guide-button.component';
 import { IbfGuidePopoverComponent } from 'src/app/components/ibf-guide-popover/ibf-guide-popover.component';
 import { LayerControlInfoPopoverComponent } from 'src/app/components/layer-control-info-popover/layer-control-info-popover.component';
@@ -69,7 +72,8 @@ import { CompactPipe } from 'src/app/pipes/compact.pipe';
     AdminLevelComponent,
     AggregatesComponent,
     AreasOfFocusSummaryComponent,
-    BackendMockScenarioComponent,
+    BackdoorFormComponent,
+    ChangePasswordPopoverComponent,
     ChatComponent,
     CommunityNotificationPhotoPopupComponent,
     CommunityNotificationPopupComponent,
@@ -82,6 +86,7 @@ import { CompactPipe } from 'src/app/pipes/compact.pipe';
     EventSwitcherComponent,
     ExportViewComponent,
     ExportViewPopoverComponent,
+    ForgotPasswordPopoverComponent,
     IbfGuideButtonComponent,
     IbfGuidePopoverComponent,
     LayerControlInfoPopoverComponent,
@@ -96,6 +101,7 @@ import { CompactPipe } from 'src/app/pipes/compact.pipe';
     TooltipPopoverComponent,
     UserStateComponent,
     UserStateMenuComponent,
+    BackendMockScenarioComponent,
     RiverGaugePopupContentComponent,
     ThresholdBarComponent,
     DynamicPointPopupComponent,
@@ -110,7 +116,8 @@ import { CompactPipe } from 'src/app/pipes/compact.pipe';
     AdminLevelComponent,
     AggregatesComponent,
     AreasOfFocusSummaryComponent,
-    BackendMockScenarioComponent,
+    BackdoorFormComponent,
+    ChangePasswordPopoverComponent,
     ChatComponent,
     CommunityNotificationPhotoPopupComponent,
     CommunityNotificationPopupComponent,
@@ -123,6 +130,7 @@ import { CompactPipe } from 'src/app/pipes/compact.pipe';
     EventSwitcherComponent,
     ExportViewComponent,
     ExportViewPopoverComponent,
+    ForgotPasswordPopoverComponent,
     IbfGuideButtonComponent,
     IbfGuidePopoverComponent,
     LayerControlInfoPopoverComponent,
@@ -138,6 +146,7 @@ import { CompactPipe } from 'src/app/pipes/compact.pipe';
     TranslateModule,
     UserStateComponent,
     UserStateMenuComponent,
+    BackendMockScenarioComponent,
     RiverGaugePopupContentComponent,
     ThresholdBarComponent,
     DynamicPointPopupComponent,

--- a/interfaces/IBF-dashboard/src/assets/i18n/en.json
+++ b/interfaces/IBF-dashboard/src/assets/i18n/en.json
@@ -31,6 +31,19 @@
     "no-data": "No data"
   },
   "login-page": {
+    "title": "Log in",
+    "email": "Email",
+    "password": "Password",
+    "welcome": "Hello! Welcome to IBF.",
+    "instruction": "This chat will guide you through the system. You will find it to the left of the screen. Please login below.",
+    "video": "Click for the IBF guide.",
+    "note": "NOTE: This portal works best on desktop or tablet using Chrome, Firefox, Safari and Microsoft Edge.<br>The portal is not compatible with Internet Explorer.<br>The portal is not optimized for mobile phones yet.",
+    "forgot-password": "Forgot password?",
+    "forgot-password-message": "If you forgot your password please send a request to ",
+    "environment-label": { "production": "Live", "stage": "Demo" }
+  },
+
+  "backdoor-page": {
     "title": "Login",
     "enter-email": "Enter your email",
     "reenter-email": "Use a different email",
@@ -48,7 +61,11 @@
   "user-state": {
     "logged-in-as": "Welcome,",
     "log-out": "Logout",
-    "manage": "Manage"
+    "manage": "Manage",
+    "password-change": "Change password",
+    "password-new": "New password",
+    "password-confirm": "Confirm password",
+    "password-error": "Passwords do not match"
   },
   "manage": {
     "account": {

--- a/services/API-service/package-lock.json
+++ b/services/API-service/package-lock.json
@@ -13,7 +13,7 @@
         "@nestjs/platform-express": "^11.1.17",
         "@nestjs/schedule": "^6.1.1",
         "@nestjs/swagger": "^11.2.6",
-        "@nestjs/terminus": "^11.1.1",
+        "@nestjs/terminus": "11.0.0-beta.1",
         "@nestjs/testing": "^11.1.17",
         "@nestjs/typeorm": "^11.0.0",
         "@turf/helpers": "^7.3.4",
@@ -2594,9 +2594,9 @@
       }
     },
     "node_modules/@nestjs/terminus": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-11.1.1.tgz",
-      "integrity": "sha512-Ssql79H+EQY/Wg108eJqN4NiNsO/tLrj+qbzOWSQUf2JE4vJQ2RG3WTqUOrYjfjWmVHD3+Ys0+azed7LSMKScw==",
+      "version": "11.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-11.0.0-beta.1.tgz",
+      "integrity": "sha512-IOWGY+gebATf7KTBSc08cMzZsizndmgfisjM6oosh8fOfaKdxxScJZv8Db0iPjB5uPd7qxIxePPECGVx5MLX4Q==",
       "license": "MIT",
       "dependencies": {
         "boxen": "5.1.2",

--- a/services/API-service/package.json
+++ b/services/API-service/package.json
@@ -85,5 +85,10 @@
     "tsc-watch": "^7.2.0",
     "tsconfig-paths": "^4.2.0",
     "yargs": "^18.0.0"
+  },
+  "overrides": {
+    "@nestjs-modules/mailer": {
+      "@nestjs/terminus": "11.0.0-beta.1"
+    }
   }
 }

--- a/services/API-service/package.json
+++ b/services/API-service/package.json
@@ -31,7 +31,7 @@
     "@nestjs/platform-express": "^11.1.17",
     "@nestjs/schedule": "^6.1.1",
     "@nestjs/swagger": "^11.2.6",
-    "@nestjs/terminus": "^11.1.1",
+    "@nestjs/terminus": "11.0.0-beta.1",
     "@nestjs/testing": "^11.1.17",
     "@nestjs/typeorm": "^11.0.0",
     "@turf/helpers": "^7.3.4",

--- a/services/API-service/src/api/country/country.controller.ts
+++ b/services/API-service/src/api/country/country.controller.ts
@@ -54,7 +54,6 @@ export class CountryController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(RolesGuard)
   @ApiOperation({ summary: 'Get countries' })
   @ApiResponse({
     status: 200,
@@ -67,7 +66,7 @@ export class CountryController {
   ): Promise<CountryEntity[]> {
     let countryCodesISO3 = [];
 
-    if (user.userRole !== UserRole.Admin) {
+    if (user && user.userRole !== UserRole.Admin) {
       countryCodesISO3 = user.countryCodesISO3;
     }
 

--- a/services/API-service/src/api/email/templates/login-code.mjml
+++ b/services/API-service/src/api/email/templates/login-code.mjml
@@ -22,7 +22,8 @@
       <mj-column>
         <mj-text
           >This is your unique code – use it to securely login into
-          <a href="<%= dashboardUrl %>/login?email=<%= to %>&code=<%= code %>"
+          <a
+            href="<%= dashboardUrl %>/login/backdoor?email=<%= to %>&code=<%= code %>"
             >IBF</a
           >
           without a password.</mj-text

--- a/services/API-service/src/api/user/dto/update-password.dto.ts
+++ b/services/API-service/src/api/user/dto/update-password.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsNotEmpty, IsOptional, IsString, MinLength } from 'class-validator';
+
+export class UpdatePasswordDto {
+  @ApiProperty({ example: 'abcd' })
+  @IsNotEmpty()
+  @MinLength(4)
+  public password: string;
+
+  @ApiProperty({ example: 'test@redcross.nl' })
+  @IsOptional()
+  @IsString()
+  public email: string;
+}

--- a/services/API-service/src/api/user/user.controller.ts
+++ b/services/API-service/src/api/user/user.controller.ts
@@ -27,6 +27,7 @@ import { RolesGuard } from '../../roles.guard';
 import { CountryDisasterType } from '../country/country-disaster.entity';
 import { DisasterType } from '../disaster-type/disaster-type.enum';
 import { CreateUserDto, DeleteUserDto, LoginUserDto } from './dto';
+import { UpdatePasswordDto } from './dto/update-password.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserDecorator } from './user.decorator';
 import { User, UserData, UserResponseObject } from './user.model';
@@ -298,5 +299,16 @@ export class UserController {
   @HttpCode(204)
   public async delete(@Body() { userId }: DeleteUserDto) {
     return this.userService.deleteUser(userId);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(RolesGuard)
+  @ApiOperation({ summary: 'Change password of user' })
+  @Post('change-password')
+  public async update(
+    @UserDecorator('userId') loggedInUserId: string,
+    @Body() userData: UpdatePasswordDto,
+  ) {
+    return this.userService.updatePassword(loggedInUserId, userData);
   }
 }

--- a/services/API-service/src/api/user/user.decorator.ts
+++ b/services/API-service/src/api/user/user.decorator.ts
@@ -13,9 +13,13 @@ export const UserDecorator = createParamDecorator(
       : null;
 
     if (token && token[1]) {
-      const decoded: User = jwt.verify(token[1], process.env.SECRET);
+      try {
+        const decoded: User = jwt.verify(token[1], process.env.SECRET);
 
-      return !!data ? decoded[data] : decoded;
+        return !!data ? decoded[data] : decoded;
+      } catch {
+        return null;
+      }
     }
   },
 );

--- a/services/API-service/src/api/user/user.entity.ts
+++ b/services/API-service/src/api/user/user.entity.ts
@@ -2,7 +2,6 @@ import { IsEmail } from 'class-validator';
 import crypto from 'crypto';
 import {
   BeforeInsert,
-  BeforeUpdate,
   Column,
   Entity,
   JoinTable,
@@ -76,11 +75,8 @@ export class UserEntity {
   public created: Date;
 
   @BeforeInsert()
-  @BeforeUpdate()
   public hashPassword(): void {
-    if (this.password && this.password.length != 64) {
-      // HACK: we use SHA-256 hash length to avoid rehashing
-      // we should use a verifable hash instead of hmac
+    if (this.password) {
       this.password = crypto.createHmac('sha256', this.password).digest('hex');
     }
   }

--- a/services/API-service/src/api/user/user.service.ts
+++ b/services/API-service/src/api/user/user.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Injectable,
   NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
@@ -16,6 +17,7 @@ import { DisasterTypeEntity } from '../disaster-type/disaster-type.entity';
 import { DisasterType } from '../disaster-type/disaster-type.enum';
 import { LookupService } from '../notification/lookup/lookup.service';
 import { CreateUserDto, LoginUserDto } from './dto';
+import { UpdatePasswordDto } from './dto/update-password.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserEntity } from './user.entity';
 import { User } from './user.model';
@@ -325,5 +327,49 @@ export class UserService {
 
   public async deleteUser(userId: string) {
     await this.userRepository.delete({ userId });
+  }
+
+  public async updatePassword(loggedInUserId: string, dto: UpdatePasswordDto) {
+    let updateUser: UserEntity;
+    const loggedInUser = await this.userRepository.findOne({
+      where: { userId: loggedInUserId },
+      relations: this.relations,
+    });
+    if (!loggedInUser) {
+      const errors = { user: 'No logged in user found' };
+      throw new NotFoundException({ errors });
+    }
+
+    if (dto.email) {
+      if (loggedInUser.userRole !== UserRole.Admin) {
+        const errors = {
+          User: 'You can only use this endpoint with email-property if you are an admin-user',
+        };
+        throw new UnauthorizedException({ errors });
+      }
+      updateUser = await this.userRepository.findOne({
+        where: { email: dto.email },
+        relations: this.relations,
+      });
+      if (!updateUser) {
+        const errors = { email: dto.email + ' not found' };
+        throw new NotFoundException({ errors });
+      }
+    } else {
+      updateUser = loggedInUser;
+    }
+    const password = crypto.createHmac('sha256', dto.password).digest('hex');
+    await this.userRepository.save({ userId: updateUser.userId, password });
+
+    const userRO = {
+      email: updateUser.email,
+      firstName: updateUser.firstName,
+      middleName: updateUser.middleName,
+      lastName: updateUser.lastName,
+      userRole: updateUser.userRole,
+      whatsappNumber: updateUser.whatsappNumber,
+    };
+
+    return { user: userRO };
   }
 }

--- a/tests/e2e/Pages/BackdoorPage.ts
+++ b/tests/e2e/Pages/BackdoorPage.ts
@@ -1,0 +1,46 @@
+import { expect } from '@playwright/test';
+import { Locator, Page } from 'playwright';
+
+import DashboardPage from './DashboardPage';
+
+class BackdoorPage extends DashboardPage {
+  readonly page: Page;
+  readonly emailInput: Locator;
+  readonly codeInput: Locator;
+  readonly loginButton: Locator;
+  readonly welcomeMessage: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.page = page;
+    this.emailInput = this.page.locator('input[type="email"]');
+    this.codeInput = this.page.locator('input[type="text"]');
+    this.loginButton = this.page.getByTestId('button-login');
+    this.welcomeMessage = this.page.getByTestId('welcome-message');
+  }
+
+  async login(email?: string) {
+    if (!email) {
+      throw new Error('Email is required to login');
+    }
+
+    const loginRequest = this.page.waitForResponse('**/api/login');
+
+    await this.emailInput.fill(email);
+    await this.loginButton.click();
+
+    const loginResponse = await loginRequest;
+    const { code } = await loginResponse.json();
+
+    await this.codeInput.fill(String(code));
+  }
+
+  async loginScreenIsVisible() {
+    await this.page.waitForSelector('[data-testid="input-email"]');
+
+    await expect(this.loginButton).toBeVisible();
+    await expect(this.welcomeMessage).toHaveText('Welcome to IBF');
+  }
+}
+
+export default BackdoorPage;

--- a/tests/e2e/Pages/LoginPage.ts
+++ b/tests/e2e/Pages/LoginPage.ts
@@ -1,45 +1,46 @@
 import { expect } from '@playwright/test';
 import { Locator, Page } from 'playwright';
 
+import englishTranslations from '../../../interfaces/IBF-dashboard/src/assets/i18n/en.json';
 import DashboardPage from './DashboardPage';
+
+const welcomeMessageEnglishTranslation =
+  englishTranslations['login-page'].welcome;
 
 class LoginPage extends DashboardPage {
   readonly page: Page;
   readonly emailInput: Locator;
-  readonly codeInput: Locator;
+  readonly passwordInput: Locator;
   readonly loginButton: Locator;
   readonly welcomeMessage: Locator;
 
   constructor(page: Page) {
     super(page);
     this.page = page;
-    this.emailInput = this.page.locator('input[type="email"]');
-    this.codeInput = this.page.locator('input[type="text"]');
-    this.loginButton = this.page.getByTestId('button-login');
-    this.welcomeMessage = this.page.getByTestId('welcome-message');
+    this.emailInput = this.page.getByLabel('Email');
+    this.passwordInput = this.page.locator('input[type="password"]');
+    this.loginButton = this.page.getByRole('button', { name: 'Log in' });
+    this.welcomeMessage = this.page.getByTestId('login-welcome-message');
   }
 
-  async login(email?: string) {
-    if (!email) {
-      throw new Error('Email is required to login');
+  async login(email?: string, password?: string) {
+    if (!email || !password) {
+      throw new Error('Email and password are required');
     }
 
-    const loginRequest = this.page.waitForResponse('**/api/login');
-
     await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
     await this.loginButton.click();
-
-    const loginResponse = await loginRequest;
-    const { code } = await loginResponse.json();
-
-    await this.codeInput.fill(String(code));
   }
 
   async loginScreenIsVisible() {
-    await this.page.waitForSelector('[data-testid="input-email"]');
+    // explicitly wait for the email input to avoid timing issues
+    await this.page.waitForSelector('input[type="email"]');
 
     await expect(this.loginButton).toBeVisible();
-    await expect(this.welcomeMessage).toHaveText('Welcome to IBF');
+    await expect(this.welcomeMessage).toHaveText(
+      welcomeMessageEnglishTranslation,
+    );
   }
 }
 

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -4,7 +4,7 @@ import {
   registerUser,
   reset,
 } from 'helpers/utility.helper';
-import LoginPage from 'Pages/LoginPage';
+import BackdoorPage from 'Pages/BackdoorPage';
 import { chromium, FullConfig } from 'playwright/test';
 import { datasets } from 'testData/datasets';
 import { UserRole } from 'testData/enums';
@@ -32,10 +32,10 @@ async function globalSetup(config: FullConfig) {
       // launch browser
       const browser = await chromium.launch();
       const page = await browser.newPage();
-      await page.goto(baseURL!);
+      await page.goto(`${baseURL!}/login/backdoor`);
 
       // login
-      const loginPage = new LoginPage(page);
+      const loginPage = new BackdoorPage(page);
       await loginPage.login(email);
       await page.waitForSelector('[data-testid=loader]', { state: 'hidden' });
 


### PR DESCRIPTION
[AB#41063](https://dev.azure.com/redcrossnl/9e7ca3cc-bb97-4471-a25c-fd9787af0fe8/_workitems/edit/41063)

## Describe your changes

1. Restore the password-login page at `/login`
2. Restore change password (frontend and backend)
3. Restore forgot password (frontend only)
4. Open `GET /country` as required by the old login page design
5. Hide passwordless-login page at `/login/backdoor`
6. Fix startup error introduced in https://github.com/rodekruis/IBF-system/pull/2590
7. Show _change password_ instead of _the manage page_ in the user menu
8. Minimal changes to tests to merge the PR
9. Remove the password hashing hack in user.entity.ts

The `/login/backdoor` and `/manage` pages are **only** accessible by entering the direct URL. They should not be accessible by normal user interaction.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests wherever relevant
- [x] I have made sure that all automated checks pass before requesting a review